### PR TITLE
Zero-Config CLI API Endpoint + Local Override Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ After launching `agon`, use these in-shell commands:
 Notes:
 - `agon --version` prints the installed CLI version and exits.
 - `agon --help` shows launcher help.
+- By default, Agon CLI connects to the hosted backend endpoint (no manual `apiUrl` setup required for end users).
 - On startup, Agon checks npm and alerts when a newer stable version is available.
 
 ### Web Application (In Development)
@@ -235,7 +236,11 @@ cd backend
 dotnet run --project src/Agon.Api/Agon.Api.csproj
 ```
 
-API default URL: `http://localhost:5000`
+For local backend testing, point the CLI to your local API process:
+
+```bash
+AGON_API_URL=http://localhost:5000 npm exec -- agon
+```
 
 #### 3) Run a local client
 

--- a/cli/.changeset/bright-clouds-rule.md
+++ b/cli/.changeset/bright-clouds-rule.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Default the CLI API endpoint to the hosted gateway for zero-config installs, while preserving local testing via the `AGON_API_URL` environment variable.

--- a/cli/src/state/config-manager.ts
+++ b/cli/src/state/config-manager.ts
@@ -19,6 +19,8 @@ import { stringify as yamlStringify } from 'yaml';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
+const DEFAULT_HOSTED_API_URL = 'http://20.111.24.4';
+
 // Configuration schema
 const ConfigSchema = z.object({
   apiUrl: z.string().url().optional(),
@@ -30,7 +32,7 @@ const ConfigSchema = z.object({
 export type AgonConfig = z.infer<typeof ConfigSchema>;
 
 const DEFAULT_CONFIG: Required<AgonConfig> = {
-  apiUrl: 'http://localhost:5000',
+  apiUrl: resolveDefaultApiUrl(),
   defaultFriction: 50,
   researchEnabled: true,
   logLevel: 'info'
@@ -159,5 +161,19 @@ export class ConfigManager {
     } catch {
       return null;
     }
+  }
+}
+
+function resolveDefaultApiUrl(): string {
+  const envUrl = process.env.AGON_API_URL?.trim();
+  if (!envUrl) {
+    return DEFAULT_HOSTED_API_URL;
+  }
+
+  try {
+    new URL(envUrl);
+    return envUrl;
+  } catch {
+    return DEFAULT_HOSTED_API_URL;
   }
 }

--- a/cli/test/state/config-manager.test.ts
+++ b/cli/test/state/config-manager.test.ts
@@ -27,7 +27,7 @@ describe('ConfigManager', () => {
       const defaults = configManager.getDefaults();
 
       // Assert
-      expect(defaults.apiUrl).toBe('http://localhost:5000');
+      expect(defaults.apiUrl).toMatch(/^https?:\/\//);
       expect(defaults.defaultFriction).toBe(50);
       expect(defaults.researchEnabled).toBe(true);
       expect(defaults.logLevel).toBe('info');
@@ -135,7 +135,7 @@ describe('ConfigManager', () => {
 
       // Assert
       expect(merged.defaultFriction).toBe(75); // From partial
-      expect(merged.apiUrl).toBe('http://localhost:5000'); // From defaults
+      expect(merged.apiUrl).toBe(configManager.getDefaults().apiUrl); // From defaults
       expect(merged.researchEnabled).toBe(true); // From defaults
       expect(merged.logLevel).toBe('info'); // From defaults
     });


### PR DESCRIPTION
## Summary
This PR removes the need for end users to manually configure `apiUrl` after installing the CLI.

The CLI now defaults to the hosted backend endpoint out of the box, while still allowing local development/testing through an environment variable override.

## Problem
Today, a new user may need to run:

```bash
agon config set apiUrl <backend-url>
```

That adds friction and can cause first-run failures if skipped.

## What Changed

### 1) CLI default API URL behavior
Updated CLI config defaults so `apiUrl` resolves as follows:

1. If `AGON_API_URL` is set and valid, use it.
2. Otherwise, use the hosted default endpoint (`http://20.111.24.4`).

File:
- `cli/src/state/config-manager.ts`

### 2) Test updates
Adjusted config-manager tests to validate URL behavior without relying on a hardcoded localhost default.

File:
- `cli/test/state/config-manager.test.ts`

### 3) Documentation update
Updated README to make behavior explicit:

- End users: no manual `apiUrl` setup required.
- Local testing: run CLI against local backend with:

```bash
AGON_API_URL=http://localhost:5000 npm exec -- agon
```

File:
- `README.md`

### 4) Changeset for CLI release
Added a patch changeset for `@agon_agents/cli`.

File:
- `cli/.changeset/bright-clouds-rule.md`

## Validation
- CLI targeted tests passed:
  - `test/state/config-manager.test.ts`
  - `test/commands/config.test.ts`
- Commit hook also ran full CLI and backend test suites successfully before commit.

## Impact
- Better first-run UX for npm-installed CLI users.
- Preserves local developer workflow without requiring persistent config edits.
- Ready for normal changesets-based CLI versioning/publish flow.

## Notes
- This PR intentionally implements the change on a feature branch only (`feature/cli-zero-config-api-endpoint`), not directly on `main`.
