### PR TITLE
fix(moderator): adaptive clarification and harden follow-up timeouts ¬ Adaptive Moderator Clarification + Follow-up Timeout Hardening

### DIFF
--- a/backend/src/Agon.Domain/Agents/AgentSystemPrompts.cs
+++ b/backend/src/Agon.Domain/Agents/AgentSystemPrompts.cs
@@ -12,7 +12,7 @@ public static class AgentSystemPrompts
 {
     public const string Moderator = @"ROLE: Moderator / Clarifier.
 
-GOAL: Turn the user's raw idea into a precise Debate Brief that can seed the Truth Map.
+GOAL: Turn the user's raw idea into a precise, execution-ready Debate Brief that can seed the Truth Map.
 
 INPUTS PROVIDED:
 - User idea (raw text)
@@ -21,43 +21,45 @@ INPUTS PROVIDED:
 - User Responses (if any - shows previous user answers)
 
 CRITICAL RULES:
-1. On the FIRST ROUND (round 0, when User Responses is empty or only contains the initial idea), you MUST ask clarifying questions. DO NOT output READY on round 0.
-2. If you ask ANY clarifying questions in your MESSAGE, you MUST NOT output READY in that same response. Wait for the user to answer first.
-3. ONLY output READY when: (a) you have received user answers to your questions, AND (b) ALL elements of the Golden Triangle are explicitly defined.
+1. On the FIRST ROUND (round 0, when User Responses is empty or only contains the initial idea), you MUST ask at least one clarifying question. DO NOT output READY on round 0.
+2. If you ask ANY clarifying questions in your MESSAGE, you MUST NOT output READY in that same response.
+3. Ask ADAPTIVE questions, not a fixed template. Focus on the highest-impact unknowns for execution.
+4. NEVER re-ask an answered question unless the new user input conflicts with previous answers; if conflicting, ask a reconciliation question.
+5. Accept explicit user stances such as ""no budget constraint"", ""no fixed timeline"", or ""no stack preference"" as valid constraints and move forward.
+6. Ask MAX 3 questions per round (prefer 1-2), ordered by impact on product decisions.
+7. Use concise, practical language. No lectures.
+8. Output READY when information is sufficient to proceed, even if some uncertainty remains; record remaining uncertainty as explicit assumptions/open questions.
 
-INSTRUCTIONS:
-1) Check the Golden Triangle. ALL three must be explicitly defined:
-   a) Target user / primary persona (specific, not ""anyone"" or ""users"")
-   b) Value proposition / problem being solved (specific pain point)
-   c) Constraints: budget (actual number), timeline (specific date/duration), tech stack, non-negotiables
+ADAPTIVE CLARIFICATION GUIDELINES:
+Prioritize unresolved items that most affect architecture, scope, and success criteria. Typical dimensions include:
+- target persona and context of use
+- core problem/value proposition
+- success metrics and acceptance criteria
+- MVP scope boundaries
+- hard constraints (budget/timeline/regulatory/platform/integrations)
+- risk-critical unknowns that could invalidate the approach
 
-2) If ANYTHING in the Golden Triangle is missing or vague, ask targeted clarifying questions.
-   - Ask MAX 3 questions per round.
-   - Ask the most important question first.
-   - Do not ask questions about things the user has already answered in User Responses.
-   - Be concise. No lectures.
-   - Examples of VAGUE that require questions:
-     * ""SaaS for project management"" (who? what specific problem?)
-     * ""flexible budget"" (what's the range?)
-     * ""ASAP"" (what's the actual deadline?)
-     * ""modern tech stack"" (what specifically?)
+Avoid ""question loops"":
+- Before asking, check User Responses + Truth Map and skip already-resolved items.
+- If user said a constraint is intentionally open, do not keep pressing for numbers unless friction policy requires it.
 
-3) ONLY output READY when ALL of these are explicitly defined:
-   - Specific target persona (e.g., ""freelance designers managing 5-10 client projects"")
-   - Specific problem (e.g., ""lose track of deadlines across multiple clients"")
-   - Numeric budget or clear range (e.g., ""$50k"" or ""$20k-$50k"")
-   - Specific timeline (e.g., ""6 months"" or ""MVP by Q3 2026"")
-   - Tech preferences if any (or explicitly ""none"")
+READY THRESHOLD:
+Output READY when these are sufficiently actionable:
+- primary_persona (specific enough to design for)
+- core_idea/problem (specific enough to implement against)
+- constraints (explicit values OR explicit ""none/open"" stance)
+- success direction (at least one measurable success signal or concrete qualitative outcome)
 
-   When outputting READY, include:
-   - core_idea (one sentence)
-   - constraints (budget, timeline, stack, non-negotiables)
-   - success_metrics (what does good look like?)
-   - primary_persona (who is this for?)
-   - open_questions (anything unresolved that agents should probe)
+When outputting READY, include in MESSAGE:
+- core_idea
+- primary_persona
+- constraints (including explicitly open constraints)
+- success_metrics
+- assumptions_made (explicit assumptions you used to proceed)
+- open_questions (non-blocking unknowns for downstream agents)
 
 FRICTION NOTE:
-- If friction_level >= 70: be extra strict — require numeric budget and specific timeline before READY.
+- If friction_level >= 70: be stricter on ambiguity in high-risk areas, but do not deadlock. If user keeps constraints open, proceed with explicit assumptions and flag risk.
 
 PATCH RULES:
 - Add or update: constraints, success_metrics, persona, open_questions.

--- a/cli/.changeset/real-bottles-think.md
+++ b/cli/.changeset/real-bottles-think.md
@@ -1,0 +1,5 @@
+---
+'@agon_agents/cli': patch
+---
+
+Improve follow-up reliability and UX by mapping gateway timeouts (HTTP 504) to backend-unavailable guidance, preserving moderator question numbering in shell rendering, and refining moderator prompt behavior to ask adaptive non-repetitive clarifications.

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -264,10 +264,15 @@ export class AgonAPIClient {
         case 500:
         case 502:
         case 503:
+        case 504:
           return new AgonError(
             ErrorCode.BACKEND_UNAVAILABLE,
             'Backend service unavailable. Please try again.',
-            ['Check if the backend is running', 'Verify API URL in config']
+            [
+              'Check if the backend is running',
+              'Verify API URL in config',
+              'If this happens during long responses, the gateway timeout may be too low'
+            ]
           );
         default:
           return new AgonError(ErrorCode.API_ERROR, message);

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -84,8 +84,9 @@ export default class Shell extends Command {
     });
     if (updateInfo) {
       this.log(chalk.yellow(`Update available: v${updateInfo.currentVersion} → v${updateInfo.latestVersion}`));
-      this.log(chalk.cyan('To update: exit Agon shell first, then run in your terminal:'));
-      this.log(chalk.cyan('  agon --self-update'));
+      this.log(chalk.cyan('To update:'));
+      this.log(chalk.cyan('  1) Exit shell now: /exit'));
+      this.log(chalk.cyan('  2) Run in terminal: agon --self-update'));
       this.log(chalk.dim('If that fails, run:'));
       this.log(chalk.dim(`  ${updateInfo.installCommand}`));
     }

--- a/cli/src/utils/markdown.ts
+++ b/cli/src/utils/markdown.ts
@@ -39,7 +39,7 @@ export function normalizeMarkdownStructure(markdown: string): string {
   const numberedPattern = /^(\d+)[.)]\s+(.+)$/;
   const bulletPattern = /^[-*•●▪◦∙·]\s+(.+)$/;
   const continuationPattern = /^(and|or|also|plus|including|where|pick|choose|reply|current|desired|what(?:'s| is)?|budget|timeline|tech|non-negotiables?)\b/i;
-  const listTerminationPattern = /^(once|after that|after you answer|then i(?:'|)ll|thanks)\b/i;
+  const listTerminationPattern = /^(once|after that|after you answer|then i(?:'|)ll|thanks|next steps?:)\b/i;
   let insideNumberedList = false;
   let numberedItemCounter = 0;
   let pendingBlank = false;
@@ -100,9 +100,12 @@ export function normalizeMarkdownStructure(markdown: string): string {
 
     if (insideNumberedList) {
       const previous = normalized.at(-1) ?? '';
-      const followsSubItem = /^\s+-\s+/.test(previous) || /^\s{5,}\S+/.test(previous);
-      if (followsSubItem && !listTerminationPattern.test(trimmed)) {
-        normalized.push(`     ${trimmed}`);
+      const followsNumberedItem = /^\d+\.\s+/.test(previous);
+      const followsSubItem = /^\s+-\s+/.test(previous);
+      const followsContinuation = /^\s{3,}\S+/.test(previous);
+      if ((followsNumberedItem || followsSubItem || followsContinuation) && !listTerminationPattern.test(trimmed)) {
+        const indent = followsNumberedItem ? '   ' : '     ';
+        normalized.push(`${indent}${trimmed}`);
         continue;
       }
     }

--- a/cli/test/api/agon-client.test.ts
+++ b/cli/test/api/agon-client.test.ts
@@ -151,6 +151,15 @@ describe('AgonAPIClient', () => {
       await expect(client.getSession(sessionId)).rejects.toThrow();
     });
 
+    it('should map 504 errors to backend unavailable', () => {
+      const error: any = new Error('Gateway Timeout');
+      error.response = { status: 504, data: {} };
+      const mapped = (client as any).mapError(error);
+      expect(mapped).toBeInstanceOf(AgonError);
+      const agonError = mapped as AgonError;
+      expect(agonError.code).toBe(ErrorCode.BACKEND_UNAVAILABLE);
+    });
+
     it('should map 426 errors to CLI upgrade required', async () => {
       const error: any = new Error('Request failed with status code 426');
       error.response = {

--- a/cli/test/utils/markdown.test.ts
+++ b/cli/test/utils/markdown.test.ts
@@ -212,6 +212,26 @@ describe('Markdown Renderer', () => {
       expect(normalized).not.toContain('\n1. Constraints you do have');
     });
 
+    it('should keep numbering progression when a numbered item contains plain continuation lines', () => {
+      const text = [
+        'Please answer these 3 questions:',
+        '',
+        '1. Primary persona (pick one for MVP): Which specific group are we designing for first? Examples: "busy urban professionals 25-40 seeking',
+        'long-term relationship," "divorced 40-60 professionals re-entering dating," "faith-based professionals," etc.',
+        '',
+        '1. Hard constraints (numbers): What is your budget and timeline?',
+        '2. Core matching behavior for MVP: What one matching outcome should AI optimize for?'
+      ].join('\n');
+
+      const normalized = normalizeMarkdownStructure(text);
+      expect(normalized).toContain('1. Primary persona (pick one for MVP): Which specific group are we designing for first? Examples: "busy urban professionals 25-40 seeking');
+      expect(normalized).toContain('   long-term relationship," "divorced 40-60 professionals re-entering dating," "faith-based professionals," etc.');
+      expect(normalized).toContain('2. Hard constraints (numbers): What is your budget and timeline?');
+      expect(normalized).toContain('3. Core matching behavior for MVP: What one matching outcome should AI optimize for?');
+      expect(normalized).not.toContain('\n1. Hard constraints');
+      expect(normalized).not.toContain('\n2. Core matching behavior for MVP');
+    });
+
     it('should keep numbering progression when option bullets use unicode bullet characters', () => {
       const text = [
         '1. Primary persona',

--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -66,6 +66,11 @@ param appGatewaySubnetPrefix string = '10.42.4.0/24'
 ])
 param appGatewayWafMode string = 'Detection'
 
+@description('Application Gateway backend request timeout in seconds.')
+@minValue(1)
+@maxValue(86400)
+param appGatewayRequestTimeoutSeconds int = 120
+
 var commonTags = {
   environment: environment
   workload: workloadName
@@ -144,6 +149,7 @@ module appEdge './modules/app-edge-dev.bicep' = {
     namePrefix: namePrefix
     alertEmail: alertEmail
     appGatewayWafMode: appGatewayWafMode
+    appGatewayRequestTimeoutSeconds: appGatewayRequestTimeoutSeconds
     appSubnetId: network.outputs.appSubnetId
     appGatewaySubnetId: network.outputs.appGatewaySubnetId
     privateEndpointSubnetId: network.outputs.privateEndpointSubnetId

--- a/infrastructure/bicep/modules/app-edge-dev.bicep
+++ b/infrastructure/bicep/modules/app-edge-dev.bicep
@@ -22,6 +22,11 @@ param alertEmail string
 ])
 param appGatewayWafMode string = 'Detection'
 
+@description('Application Gateway backend request timeout in seconds.')
+@minValue(1)
+@maxValue(86400)
+param appGatewayRequestTimeoutSeconds int = 120
+
 @description('App Service VNet integration subnet resource ID.')
 param appSubnetId string
 
@@ -274,7 +279,7 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' = {
         properties: {
           protocol: 'Https'
           port: 443
-          requestTimeout: 30
+          requestTimeout: appGatewayRequestTimeoutSeconds
           hostName: appService.properties.defaultHostName
           pickHostNameFromBackendAddress: false
           probe: {

--- a/infrastructure/bicep/parameters/dev.parameters.json
+++ b/infrastructure/bicep/parameters/dev.parameters.json
@@ -32,6 +32,9 @@
     "appGatewayWafMode": {
       "value": "Detection"
     },
+    "appGatewayRequestTimeoutSeconds": {
+      "value": 120
+    },
     "alertEmail": {
       "value": "simonholmesabc@gmail.com"
     },


### PR DESCRIPTION
## Summary
This PR addresses two stability/UX issues that were affecting real sessions:

1. The moderator repeatedly asked the same rigid "Golden Triangle" questions.
2. Follow-up rounds could fail with intermittent HTTP 504 errors after working initially.

It introduces an adaptive moderator strategy and increases App Gateway timeout headroom for long follow-up responses.

## Why
- The clarification flow felt repetitive and blocked progress even when users had already answered.
- App Gateway was configured with a backend request timeout (`30s`) lower than realistic end-to-end follow-up processing time, causing timeout-based instability in later rounds.

## Changes

### 1) Moderator prompt refactor (backend)
File:
- `backend/src/Agon.Domain/Agents/AgentSystemPrompts.cs`

What changed:
- Replaced rigid Golden Triangle-first behavior with adaptive, highest-impact clarifying questions.
- Added anti-repeat behavior: do not re-ask already answered questions unless conflicting answers appear.
- Accept explicit user stances like "no budget constraint" or "no fixed timeline" as valid constraints.
- Allow progression with explicit assumptions + open questions instead of looping.
- Preserved first-round Q/A and READY semantics so orchestrator contract remains intact.

### 2) App Gateway timeout hardening (infrastructure)
Files:
- `infrastructure/bicep/modules/app-edge-dev.bicep`
- `infrastructure/bicep/main.bicep`
- `infrastructure/bicep/parameters/dev.parameters.json`

What changed:
- Added `appGatewayRequestTimeoutSeconds` parameter.
- Wired parameter from `main.bicep` into `app-edge-dev.bicep`.
- Set dev default to `120` seconds (from implicit `30` seconds in backend HTTP settings).

Expected impact:
- Reduces/avoids intermittent 504s on longer follow-up requests.

### 3) CLI error mapping improvement for gateway timeouts
Files:
- `cli/src/api/agon-client.ts`
- `cli/test/api/agon-client.test.ts`

What changed:
- Map HTTP `504` into `BACKEND_UNAVAILABLE` (same bucket as 500/502/503).
- Added clearer suggestion text for timeout scenarios.
- Added test coverage for 504 mapping.

### 4) Shell rendering polish already pending in branch
Files:
- `cli/src/commands/shell.ts`
- `cli/src/utils/markdown.ts`
- `cli/test/utils/markdown.test.ts`

What changed:
- Clarified update instructions in shell output.
- Preserved numbered-list progression and spacing in moderator-style question blocks.
- Added regression coverage for numbering behavior.

### 5) Changeset
Added:
- `cli/.changeset/real-bottles-think.md`

Type:
- `@agon_agents/cli`: `patch`

## Validation
- `npm --prefix cli run test -- --run test/api/agon-client.test.ts test/utils/markdown.test.ts` ✅
- `dotnet test backend/tests/Agon.Application.Tests/Agon.Application.Tests.csproj --verbosity minimal` ✅
- `az bicep build --file infrastructure/bicep/main.bicep` ✅
- `az bicep build --file infrastructure/bicep/modules/app-edge-dev.bicep` ✅

## Deployment Notes
- Infrastructure must be redeployed for App Gateway timeout changes to take effect.
- After deploy, verify backend health and run a long follow-up flow to confirm 504 resolution.

## Risk
- Low-to-moderate prompt behavior change risk: moderator questioning style will be noticeably less rigid.
- Infra timeout increase is low risk and improves resilience for long-running follow-ups.
