### PR TITLE
fix: set App Gateway request routing rule priority for Basic SKU deployments

### DIFF
--- a/infrastructure/bicep/modules/app-edge-dev.bicep
+++ b/infrastructure/bicep/modules/app-edge-dev.bicep
@@ -262,7 +262,7 @@ var redirectConfigurations = enableHttpsListener
       }
     ]
   : []
-var httpRedirectRuleProperties = union({
+var httpRedirectRuleProperties = {
   ruleType: 'Basic'
   httpListener: {
     id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, httpListenerName)
@@ -270,10 +270,9 @@ var httpRedirectRuleProperties = union({
   redirectConfiguration: {
     id: resourceId('Microsoft.Network/applicationGateways/redirectConfigurations', appGatewayName, httpToHttpsRedirectName)
   }
-}, isV2Sku ? {
   priority: 90
-} : {})
-var httpsRequestRoutingRuleProperties = union({
+}
+var httpsRequestRoutingRuleProperties = {
   ruleType: 'Basic'
   httpListener: {
     id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, httpsListenerName)
@@ -284,10 +283,9 @@ var httpsRequestRoutingRuleProperties = union({
   backendHttpSettings: {
     id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, backendHttpSettingsName)
   }
-}, isV2Sku ? {
   priority: 100
-} : {})
-var defaultRequestRoutingRuleProperties = union({
+}
+var defaultRequestRoutingRuleProperties = {
   ruleType: 'Basic'
   httpListener: {
     id: resourceId('Microsoft.Network/applicationGateways/httpListeners', appGatewayName, httpListenerName)
@@ -298,9 +296,8 @@ var defaultRequestRoutingRuleProperties = union({
   backendHttpSettings: {
     id: resourceId('Microsoft.Network/applicationGateways/backendHttpSettingsCollection', appGatewayName, backendHttpSettingsName)
   }
-}, isV2Sku ? {
   priority: 100
-} : {})
+}
 var requestRoutingRules = enableHttpsListener
   ? [
       {


### PR DESCRIPTION
## Summary
Fixes the `Infrastructure Deploy (Dev)` failure introduced after PR #90 merge.

The deployment failed with:
- `ApplicationGatewayRequestRoutingRulePriorityCannotBeEmpty`
- Resource: `Microsoft.Network/applicationGateways/.../requestRoutingRules/rule-default`

## Root Cause
In `infrastructure/bicep/modules/app-edge-dev.bicep`, request routing rule `priority` was only added for `_v2` SKUs. The current `Basic` deployment path also requires `priority` for this API version.

## Changes
- Updated App Gateway routing rule properties to always set explicit priorities:
  - HTTP redirect rule: `priority: 90`
  - HTTPS/default backend rule: `priority: 100`

## Validation
- `az bicep build --file infrastructure/bicep/main.bicep` succeeds locally.
- Exact failing Actions log confirmed before fix from run `23215008333`:
  - `ApplicationGatewayRequestRoutingRulePriorityCannotBeEmpty`

## Notes
- Leaves `infrastructure/architecture/` untouched/untracked as requested.
