### PR TITLE
fix: isolate Basic App Gateway to dedicated v1 subnet

### DIFF
--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -59,6 +59,9 @@ param postgresSubnetPrefix string = '10.42.3.0/24'
 @description('Application Gateway dedicated subnet prefix.')
 param appGatewaySubnetPrefix string = '10.42.4.0/24'
 
+@description('Application Gateway dedicated subnet prefix for Basic/legacy (v1 family) SKUs.')
+param appGatewayV1SubnetPrefix string = '10.42.5.0/24'
+
 @description('Optional suffix for Application Gateway resources to support parallel replacement cutovers (for example: v1).')
 @maxLength(20)
 param appGatewayResourceSuffix string = ''
@@ -143,6 +146,7 @@ var netResourceGroupName = 'rg-${namePrefix}-net'
 var appResourceGroupName = 'rg-${namePrefix}-app'
 var dataResourceGroupName = 'rg-${namePrefix}-data'
 var appServiceName = 'app-${namePrefix}-${take(uniqueString(subscription().id, rgApp.id, namePrefix, environment), 12)}'
+var isV2AppGatewayTier = endsWith(toLower(appGatewaySkuTier), '_v2')
 
 resource rgNet 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: netResourceGroupName
@@ -175,6 +179,7 @@ module network './modules/network-dev.bicep' = {
     privateEndpointSubnetPrefix: privateEndpointSubnetPrefix
     postgresSubnetPrefix: postgresSubnetPrefix
     appGatewaySubnetPrefix: appGatewaySubnetPrefix
+    appGatewayV1SubnetPrefix: appGatewayV1SubnetPrefix
   }
 }
 
@@ -225,7 +230,7 @@ module appEdge './modules/app-edge-dev.bicep' = {
     appGatewaySslCertificatePfxBase64: appGatewaySslCertificatePfxBase64
     appGatewaySslCertificatePassword: appGatewaySslCertificatePassword
     appSubnetId: network.outputs.appSubnetId
-    appGatewaySubnetId: network.outputs.appGatewaySubnetId
+    appGatewaySubnetId: isV2AppGatewayTier ? network.outputs.appGatewaySubnetId : network.outputs.appGatewayV1SubnetId
     privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
     appServicePrivateDnsZoneId: network.outputs.appServicePrivateDnsZoneId
     postgresServerName: data.outputs.postgresqlServerName

--- a/infrastructure/bicep/modules/network-dev.bicep
+++ b/infrastructure/bicep/modules/network-dev.bicep
@@ -27,6 +27,9 @@ param postgresSubnetPrefix string
 @description('Application Gateway dedicated subnet prefix.')
 param appGatewaySubnetPrefix string
 
+@description('Application Gateway dedicated subnet prefix for Basic/legacy (v1 family) SKUs.')
+param appGatewayV1SubnetPrefix string
+
 var tags = {
   environment: environment
   workload: workloadName
@@ -38,6 +41,7 @@ var appSubnetName = 'snet-${namePrefix}-app'
 var privateEndpointSubnetName = 'snet-${namePrefix}-pep'
 var postgresSubnetName = 'snet-${namePrefix}-psql'
 var appGatewaySubnetName = 'snet-${namePrefix}-agw'
+var appGatewayV1SubnetName = 'snet-${namePrefix}-agw-v1'
 
 var keyVaultPrivateDnsZoneName = 'privatelink.vaultcore.azure.net'
 var redisPrivateDnsZoneName = 'privatelink.redis.cache.windows.net'
@@ -97,6 +101,12 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
           addressPrefix: appGatewaySubnetPrefix
         }
       }
+      {
+        name: appGatewayV1SubnetName
+        properties: {
+          addressPrefix: appGatewayV1SubnetPrefix
+        }
+      }
     ]
   }
 }
@@ -119,6 +129,11 @@ resource postgresSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' e
 resource appGatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
   parent: vnet
   name: appGatewaySubnetName
+}
+
+resource appGatewayV1Subnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  parent: vnet
+  name: appGatewayV1SubnetName
 }
 
 resource keyVaultPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -216,6 +231,7 @@ output appSubnetId string = appSubnet.id
 output privateEndpointSubnetId string = privateEndpointSubnet.id
 output postgresSubnetId string = postgresSubnet.id
 output appGatewaySubnetId string = appGatewaySubnet.id
+output appGatewayV1SubnetId string = appGatewayV1Subnet.id
 output keyVaultPrivateDnsZoneId string = keyVaultPrivateDnsZone.id
 output redisPrivateDnsZoneId string = redisPrivateDnsZone.id
 output postgresPrivateDnsZoneId string = postgresPrivateDnsZone.id

--- a/infrastructure/bicep/parameters/dev.parameters.json
+++ b/infrastructure/bicep/parameters/dev.parameters.json
@@ -29,6 +29,9 @@
     "appGatewaySubnetPrefix": {
       "value": "10.42.4.0/24"
     },
+    "appGatewayV1SubnetPrefix": {
+      "value": "10.42.5.0/24"
+    },
     "appGatewayResourceSuffix": {
       "value": "basic"
     },


### PR DESCRIPTION
## Summary
Fixes the `Infrastructure Deploy (Dev)` failure after PR #95 merge.

## What failed
Run `23215865400` failed deploying `agw-agon-dev-frc-basic` with a terminal `InternalServerError`.

## Root cause
The Basic gateway (v1 family / Generation_1) and the existing `WAF_v2` gateway were using the same subnet (`snet-agon-dev-frc-agw`).

Azure does not support mixing v1 and v2 Application Gateway families in the same subnet.

## Changes
- Added dedicated subnet parameter for Basic/legacy gateway family:
  - `appGatewayV1SubnetPrefix` (dev: `10.42.5.0/24`)
- Updated network module to create and output:
  - `snet-agon-dev-frc-agw-v1`
  - `appGatewayV1SubnetId`
- Updated main deployment to route App Gateway subnet by SKU tier:
  - `_v2` SKUs -> existing `appGatewaySubnetId`
  - Basic/legacy SKUs -> new `appGatewayV1SubnetId`

## Validation
- `az bicep build` succeeded.
- `az deployment sub validate` succeeded.
- `az deployment sub what-if` now shows:
  - creation of `snet-agon-dev-frc-agw-v1`
  - update of `agw-agon-dev-frc-basic` `gatewayIPConfigurations[*].subnet.id` to the new v1 subnet.
