### PR TITLE
fix: align App Gateway Basic deployment with v1 public IP model

### DIFF
--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -89,7 +89,7 @@ param appGatewaySkuName string = 'Basic'
 ])
 param appGatewaySkuTier string = 'Basic'
 
-@description('Application Gateway instance count for legacy v1 SKUs. Ignored for Basic/Standard_v2/WAF_v2.')
+@description('Application Gateway instance count for v1 SKUs (Basic/Standard/WAF family). Ignored for Standard_v2/WAF_v2.')
 @minValue(1)
 @maxValue(32)
 param appGatewayInstanceCount int = 1

--- a/infrastructure/bicep/modules/app-edge-dev.bicep
+++ b/infrastructure/bicep/modules/app-edge-dev.bicep
@@ -42,7 +42,7 @@ param appGatewaySkuName string = 'Basic'
 ])
 param appGatewaySkuTier string = 'Basic'
 
-@description('Application Gateway instance count for legacy v1 SKUs. Ignored for Basic/Standard_v2/WAF_v2.')
+@description('Application Gateway instance count for v1 SKUs (Basic/Standard/WAF family). Ignored for Standard_v2/WAF_v2.')
 @minValue(1)
 @maxValue(32)
 param appGatewayInstanceCount int = 1
@@ -138,7 +138,6 @@ var actionGroupName = 'ag-${namePrefix}-ops'
 
 var appGatewayResourceSuffixSegment = empty(appGatewayResourceSuffix) ? '' : '-${appGatewayResourceSuffix}'
 var appGatewayName = 'agw-${namePrefix}${appGatewayResourceSuffixSegment}'
-var appGatewayPublicIpName = 'pip-${namePrefix}-agw${appGatewayResourceSuffixSegment}'
 var frontendIpConfigName = 'feip-public'
 var frontendHttpPortName = 'feport-80'
 var frontendHttpsPortName = 'feport-443'
@@ -154,9 +153,11 @@ var httpToHttpsRedirectName = 'redirect-http-to-https'
 var appGatewaySslCertificateName = 'agw-cert'
 var enableHttpsListener = !empty(appGatewaySslCertificatePfxBase64) && !empty(appGatewaySslCertificatePassword)
 var isV2Sku = endsWith(toLower(appGatewaySkuTier), '_v2')
-var isModernSku = toLower(appGatewaySkuTier) == 'basic' || isV2Sku
 var isWafSku = startsWith(toLower(appGatewaySkuTier), 'waf')
-var isLegacyV1Sku = !isModernSku
+var isLegacyV1Sku = !isV2Sku
+var appGatewayPublicIpName = isV2Sku
+  ? 'pip-${namePrefix}-agw${appGatewayResourceSuffixSegment}'
+  : 'pip-${namePrefix}-agw-v1${appGatewayResourceSuffixSegment}'
 var appGatewaySku = isLegacyV1Sku
   ? {
       name: appGatewaySkuName
@@ -167,8 +168,8 @@ var appGatewaySku = isLegacyV1Sku
       name: appGatewaySkuName
       tier: appGatewaySkuTier
     }
-var appGatewayPublicIpSkuName = isModernSku ? 'Standard' : 'Basic'
-var appGatewayPublicIpAllocationMethod = isModernSku ? 'Static' : 'Dynamic'
+var appGatewayPublicIpSkuName = isV2Sku ? 'Standard' : 'Basic'
+var appGatewayPublicIpAllocationMethod = isV2Sku ? 'Static' : 'Dynamic'
 var frontendPorts = enableHttpsListener
   ? [
       {


### PR DESCRIPTION
## Summary
Fixes repeated `Infrastructure Deploy (Dev)` failures on `agw-agon-dev-frc-basic`.

## Root cause
The template treated `Basic` as a modern/v2-style path for Public IP config, creating:
- Public IP SKU: `Standard`
- Allocation: `Static`

For Application Gateway v1-family SKUs (including `Basic`), expected model is v1-style Public IP (`Basic` + `Dynamic`) and explicit capacity.

## Changes
- Reclassified `Basic` as v1-family behavior in App Gateway module logic:
  - `isLegacyV1Sku = !isV2Sku`
- For v1-family SKUs, now sets:
  - Public IP SKU: `Basic`
  - Public IP allocation: `Dynamic`
  - Explicit gateway `sku.capacity`
- Added distinct v1 Public IP naming path to avoid immutable SKU conflicts with pre-existing `pip-...-agw-basic`:
  - new name format for v1-family: `pip-${namePrefix}-agw-v1${suffix}`

## Validation
- `az bicep build` succeeded.
- Subscription what-if confirms:
  - `+ Microsoft.Network/publicIPAddresses/pip-agon-dev-frc-agw-v1-basic` (Basic/Dynamic)
  - `~ Microsoft.Network/applicationGateways/agw-agon-dev-frc-basic` now points to new v1 public IP and includes `sku.capacity: 1`.

## Additional action already applied
- Registered required subscription feature:
  - `Microsoft.Network/AllowApplicationGatewayBasicSku` = `Registered`
- Re-registered provider:
  - `Microsoft.Network`
