### PR TITLE
feat(cli): support true attach-anytime behavior

### DIFF
--- a/cli/.changeset/calm-planes-rescue.md
+++ b/cli/.changeset/calm-planes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Enable true "attach anytime" behavior by auto-creating a session when none is active, and by recovering from stale session pointers when upload returns SESSION_NOT_FOUND.

--- a/cli/src/shell/controller.ts
+++ b/cli/src/shell/controller.ts
@@ -5,7 +5,9 @@ import {
   isPostDeliveryPhase,
   normalizeStatus
 } from '../utils/session-flow.js';
+import { AgonError, ErrorCode } from '../utils/error-handler.js';
 import type { ShellSettableKey } from './types.js';
+import path from 'node:path';
 
 interface ApiClientLike {
   createSession(request: {
@@ -252,12 +254,24 @@ export class ShellController {
     filePath: string,
     explicitSessionId?: string
   ): Promise<{ sessionId: string; attachment: SessionAttachment }> {
-    const sessionId = await this.resolveSessionId(explicitSessionId);
+    let sessionId = await this.resolveSessionId(explicitSessionId);
     if (!sessionId) {
-      throw new Error('No active session found. Start or resume a session before attaching documents.');
+      sessionId = await this.createSessionForAttachment(filePath);
     }
 
-    const attachment = await this.apiClient.uploadAttachment(sessionId, filePath);
+    let attachment: SessionAttachment;
+    try {
+      attachment = await this.apiClient.uploadAttachment(sessionId, filePath);
+    } catch (error) {
+      // Recover from stale local session pointers by creating a fresh session
+      // and retrying once, enabling true "attach anytime" behavior.
+      if (!explicitSessionId && this.isSessionNotFoundError(error)) {
+        sessionId = await this.createSessionForAttachment(filePath);
+        attachment = await this.apiClient.uploadAttachment(sessionId, filePath);
+      } else {
+        throw error;
+      }
+    }
 
     // Ensure shell remains pinned to this active discussion session.
     this.shellSessionId = sessionId;
@@ -401,5 +415,32 @@ export class ShellController {
     }
 
     return { session: latestSession };
+  }
+
+  private isSessionNotFoundError(error: unknown): boolean {
+    return error instanceof AgonError && error.code === ErrorCode.SESSION_NOT_FOUND;
+  }
+
+  private async createSessionForAttachment(filePath: string): Promise<string> {
+    const config = await this.configManager.load();
+    const fileName = path.basename(filePath);
+    const idea = `Discuss attached document: ${fileName}`;
+
+    const created = await this.apiClient.createSession({
+      idea,
+      friction: config.defaultFriction,
+      researchEnabled: config.researchEnabled
+    });
+
+    await this.sessionManager.saveSession(created);
+    await this.sessionManager.setCurrentSessionId(created.id);
+    this.shellSessionId = created.id;
+    this.awaitingNewIdea = false;
+
+    await this.apiClient.startSession(created.id);
+    const latest = await this.apiClient.getSession(created.id);
+    await this.sessionManager.saveSession(latest);
+
+    return created.id;
   }
 }

--- a/cli/test/shell/controller.test.ts
+++ b/cli/test/shell/controller.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Message, SessionResponse } from '../../src/api/types.js';
 import { ShellController } from '../../src/shell/controller.js';
+import { AgonError, ErrorCode } from '../../src/utils/error-handler.js';
 
 describe('shell controller', () => {
   let apiClient: any;
@@ -258,6 +259,89 @@ describe('shell controller', () => {
     expect(apiClient.uploadAttachment).toHaveBeenCalledWith('session-123', './brief.md');
     expect(result.sessionId).toBe('session-123');
     expect(result.attachment.fileName).toBe('brief.md');
+  });
+
+  it('auto-creates and starts a session when attaching without any active session', async () => {
+    const intakeSession: SessionResponse = {
+      ...baseSession,
+      id: 'session-new',
+      phase: 'Intake'
+    };
+    const clarificationSession: SessionResponse = {
+      ...baseSession,
+      id: 'session-new',
+      phase: 'Clarification'
+    };
+
+    sessionManager.getCurrentSessionId.mockResolvedValue(null);
+    sessionManager.listSessions.mockResolvedValue([]);
+    apiClient.createSession.mockResolvedValue(intakeSession);
+    apiClient.startSession.mockResolvedValue(undefined);
+    apiClient.getSession.mockResolvedValue(clarificationSession);
+    apiClient.uploadAttachment.mockResolvedValue({
+      id: 'att-new',
+      sessionId: 'session-new',
+      fileName: 'brief.md',
+      contentType: 'text/markdown',
+      sizeBytes: 2048,
+      accessUrl: 'https://example.test/brief.md',
+      uploadedAt: '2026-03-16T12:00:00Z',
+      hasExtractedText: true
+    });
+
+    const result = await controller.attachDocument('/tmp/brief.md');
+
+    expect(apiClient.createSession).toHaveBeenCalledWith({
+      idea: 'Discuss attached document: brief.md',
+      friction: 50,
+      researchEnabled: true
+    });
+    expect(apiClient.startSession).toHaveBeenCalledWith('session-new');
+    expect(apiClient.uploadAttachment).toHaveBeenCalledWith('session-new', '/tmp/brief.md');
+    expect(sessionManager.setCurrentSessionId).toHaveBeenCalledWith('session-new');
+    expect(result.sessionId).toBe('session-new');
+  });
+
+  it('recovers from stale session not found by creating a fresh session and retrying attachment', async () => {
+    const intakeSession: SessionResponse = {
+      ...baseSession,
+      id: 'session-fresh',
+      phase: 'Intake'
+    };
+    const clarificationSession: SessionResponse = {
+      ...baseSession,
+      id: 'session-fresh',
+      phase: 'Clarification'
+    };
+
+    sessionManager.getCurrentSessionId.mockResolvedValue('session-stale');
+    apiClient.uploadAttachment
+      .mockRejectedValueOnce(new AgonError(ErrorCode.SESSION_NOT_FOUND, 'Session session-stale not found'))
+      .mockResolvedValueOnce({
+        id: 'att-fresh',
+        sessionId: 'session-fresh',
+        fileName: 'cv.pdf',
+        contentType: 'application/pdf',
+        sizeBytes: 4096,
+        accessUrl: 'https://example.test/cv.pdf',
+        uploadedAt: '2026-03-16T12:00:00Z',
+        hasExtractedText: true
+      });
+    apiClient.createSession.mockResolvedValue(intakeSession);
+    apiClient.startSession.mockResolvedValue(undefined);
+    apiClient.getSession.mockResolvedValue(clarificationSession);
+
+    const result = await controller.attachDocument('/tmp/cv.pdf');
+
+    expect(apiClient.uploadAttachment).toHaveBeenNthCalledWith(1, 'session-stale', '/tmp/cv.pdf');
+    expect(apiClient.createSession).toHaveBeenCalledWith({
+      idea: 'Discuss attached document: cv.pdf',
+      friction: 50,
+      researchEnabled: true
+    });
+    expect(apiClient.startSession).toHaveBeenCalledWith('session-fresh');
+    expect(apiClient.uploadAttachment).toHaveBeenNthCalledWith(2, 'session-fresh', '/tmp/cv.pdf');
+    expect(result.sessionId).toBe('session-fresh');
   });
 
   it('treats /new as awaiting-idea mode and ignores persisted current session', async () => {


### PR DESCRIPTION
## Summary
- enable `/attach` to work even when no active session exists by auto-creating and starting a new session
- add stale-session recovery: when upload returns `SESSION_NOT_FOUND`, auto-create a fresh session and retry upload once
- keep explicit session-id behavior strict (no auto-recovery override when user explicitly targets a session)

## Implementation
- updated shell controller attach flow in `cli/src/shell/controller.ts`
- added focused tests in `cli/test/shell/controller.test.ts`
- added changeset for CLI patch release

## Validation
- targeted controller tests passed
- pre-commit hooks passed (full CLI + backend test suites)