### PR TITLE
feat(cli): allow file-path attach without /attach

### DIFF
--- a/cli/.changeset/auto-attach-path-input.md
+++ b/cli/.changeset/auto-attach-path-input.md
@@ -1,0 +1,10 @@
+---
+"@agon_agents/cli": patch
+---
+
+Improve shell attachment UX by allowing file-path-first input without requiring `/attach`.
+
+- Auto-attach when plain input starts with a valid local file path.
+- Support escaped-space file paths commonly produced by terminal drag-and-drop.
+- If path input includes trailing text, attach first then treat trailing text as the follow-up message.
+- Keep explicit `/attach` behavior unchanged.

--- a/cli/src/shell/engine.ts
+++ b/cli/src/shell/engine.ts
@@ -1,6 +1,9 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { SessionResponse } from '../api/types.js';
 import type { SelfUpdateFailureCategory } from '../utils/self-update.js';
-import { extractInlineAttach, parseShellInput } from './parser.js';
+import { extractImplicitAttach, extractInlineAttach, parseShellInput } from './parser.js';
 import { styleAttachmentToken } from './renderer.js';
 import type { PlainInputRoute } from './router.js';
 
@@ -165,6 +168,42 @@ export class ShellEngine {
       plainText = inlineAttach.remainingText;
     }
 
+    if (!inlineAttach) {
+      const implicitAttach = extractImplicitAttach(text);
+      if (implicitAttach?.type === 'attach') {
+        const resolvedPath = await resolvePathIfExisting(implicitAttach.path);
+        if (resolvedPath) {
+          const result = await this.controller.attachDocument(resolvedPath);
+          if (!implicitAttach.remainingText) {
+            return {
+              kind: 'attachment',
+              sessionId: result.sessionId,
+              fileName: result.attachment.fileName,
+              contentType: result.attachment.contentType,
+              sizeBytes: result.attachment.sizeBytes,
+              hasExtractedText: result.attachment.hasExtractedText
+            };
+          }
+
+          this.print(
+            `Attached ${styleAttachmentToken(result.attachment.fileName)} to session ${result.sessionId}.`
+            + ` Type: ${result.attachment.contentType} | Size: ${result.attachment.sizeBytes} B`
+          );
+          if (result.attachment.hasExtractedText) {
+            this.print('Document text extracted and added to agent context.');
+          } else {
+            this.print('No text extraction available; file metadata/link still added to context.');
+          }
+
+          plainText = implicitAttach.remainingText;
+        } else if (!implicitAttach.remainingText) {
+          this.print(`File not found: ${implicitAttach.path}`);
+          this.print('Use /attach <file-path> for explicit attach, or provide a valid local file path.');
+          return { kind: 'noop' };
+        }
+      }
+    }
+
     const activeSession = await this.controller.getActiveSession();
     const route = this.routePlainInputFn(activeSession);
 
@@ -235,6 +274,8 @@ export class ShellEngine {
         this.print('  /set apiUrl https://api-dev.agon-agents.org');
         this.print('  /unset apiUrl');
         this.print('  /attach ./docs/product-brief.md');
+        this.print('  /Users/simonholmes/Documents/brief.pdf');
+        this.print('  /Users/simonholmes/Documents/brief.pdf summarize the risks');
         return { kind: 'noop' };
       }
       case 'params': {
@@ -381,4 +422,34 @@ export class ShellEngine {
       }
     }
   }
+}
+
+async function resolvePathIfExisting(inputPath: string): Promise<string | null> {
+  const expandedPath = expandTilde(inputPath.trim());
+  if (!expandedPath) {
+    return null;
+  }
+
+  const absolutePath = path.isAbsolute(expandedPath)
+    ? expandedPath
+    : path.resolve(expandedPath);
+
+  try {
+    const stat = await fs.stat(absolutePath);
+    if (!stat.isFile()) {
+      return null;
+    }
+
+    return absolutePath;
+  } catch {
+    return null;
+  }
+}
+
+function expandTilde(value: string): string {
+  if (!value.startsWith('~/')) {
+    return value;
+  }
+
+  return path.join(os.homedir(), value.slice(2));
 }

--- a/cli/src/shell/parser.ts
+++ b/cli/src/shell/parser.ts
@@ -67,6 +67,12 @@ export function parseShellInput(input: string): ParsedShellInput {
     case 'followup':
       return parseFollowUp(rawArgs);
     default:
+      if (isLikelyPathToken(commandToken)) {
+        return {
+          type: 'plain',
+          text: trimmed
+        };
+      }
       return {
         type: 'error',
         message: 'Unknown command. Use /help for available commands.'
@@ -117,6 +123,30 @@ export function extractInlineAttach(input: string): InlineAttachExtraction | nul
 
   const remainingText = normalizeInlineMessageText(`${input.slice(0, commandStart)} ${input.slice(parsedPath.nextIndex)}`);
 
+  return {
+    type: 'attach',
+    path: parsedPath.path,
+    remainingText
+  };
+}
+
+export function extractImplicitAttach(input: string): InlineAttachExtraction | null {
+  const leadingWhitespaceTrimmed = input.trimStart();
+  if (!leadingWhitespaceTrimmed) {
+    return null;
+  }
+
+  const startIndex = input.length - leadingWhitespaceTrimmed.length;
+  const parsedPath = parseAttachPathToken(input, startIndex);
+  if (!parsedPath) {
+    return null;
+  }
+
+  if (!isPathLikeCandidate(parsedPath.path)) {
+    return null;
+  }
+
+  const remainingText = normalizeInlineMessageText(input.slice(parsedPath.nextIndex));
   return {
     type: 'attach',
     path: parsedPath.path,
@@ -396,13 +426,23 @@ function parseAttachPathToken(
     rawPath = input.slice(cursor + 1, pathEnd);
     nextIndex = pathEnd + 1;
   } else {
-    while (nextIndex < input.length && !/\s/.test(input[nextIndex] ?? '')) {
+    while (nextIndex < input.length) {
+      const char = input[nextIndex] ?? '';
+      if (char === '\\' && nextIndex + 1 < input.length) {
+        nextIndex += 2;
+        continue;
+      }
+
+      if (/\s/.test(char)) {
+        break;
+      }
+
       nextIndex += 1;
     }
     rawPath = input.slice(cursor, nextIndex);
   }
 
-  const normalizedPath = rawPath.trim();
+  const normalizedPath = decodeEscapedPath(rawPath).trim();
   if (!normalizedPath) {
     return null;
   }
@@ -418,4 +458,27 @@ function normalizeInlineMessageText(value: string): string {
     .replace(/\s+/g, ' ')
     .replace(/\s+([.,!?;:])/g, '$1')
     .trim();
+}
+
+function decodeEscapedPath(rawPath: string): string {
+  return rawPath.replace(/\\(.)/g, '$1');
+}
+
+function isPathLikeCandidate(value: string): boolean {
+  return value.startsWith('/')
+    || value.startsWith('./')
+    || value.startsWith('../')
+    || value.startsWith('~/')
+    || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isLikelyPathToken(value: string): boolean {
+  if (!value.startsWith('/')) {
+    return false;
+  }
+
+  const withoutLeadingSlash = value.slice(1);
+  return withoutLeadingSlash.includes('/')
+    || withoutLeadingSlash.includes('.')
+    || withoutLeadingSlash.includes('\\');
 }

--- a/cli/src/shell/renderer.ts
+++ b/cli/src/shell/renderer.ts
@@ -270,7 +270,7 @@ export function renderStatusLine(print: (line: string) => void): void {
       + chalk.cyan('/new')
       + chalk.dim(' for a new idea, ')
       + chalk.cyan('/attach')
-      + chalk.dim(' to add a document, ')
+      + chalk.dim(' or paste/drag a file path to add a document, ')
       + chalk.cyan('/params')
       + chalk.dim(' to view params, ')
       + chalk.cyan('/set')

--- a/cli/test/shell/engine.test.ts
+++ b/cli/test/shell/engine.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionResponse } from '../../src/api/types.js';
 import { ShellEngine } from '../../src/shell/engine.js';
 
@@ -8,6 +11,7 @@ describe('shell engine', () => {
   let print: ReturnType<typeof vi.fn>;
   let routeFn: ReturnType<typeof vi.fn>;
   let engine: ShellEngine;
+  let tempDirs: string[];
 
   const session: SessionResponse = {
     id: 'session-123',
@@ -18,6 +22,7 @@ describe('shell engine', () => {
   };
 
   beforeEach(() => {
+    tempDirs = [];
     controller = {
       getParamsSnapshot: vi.fn().mockResolvedValue({
         config: {
@@ -86,6 +91,12 @@ describe('shell engine', () => {
       selfUpdate,
       print
     });
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((tempDir) => fs.rm(tempDir, { recursive: true, force: true }))
+    );
   });
 
   it('executes /set via controller', async () => {
@@ -248,6 +259,60 @@ describe('shell engine', () => {
       sizeBytes: 1024,
       hasExtractedText: true
     });
+  });
+
+  it('auto-attaches when plain input is an existing local file path', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agon-shell-engine-'));
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, 'brief.md');
+    await fs.writeFile(filePath, '# brief', 'utf-8');
+
+    const outcome = await engine.handleInput(filePath);
+
+    expect(controller.attachDocument).toHaveBeenCalledWith(filePath);
+    expect(controller.startIdea).not.toHaveBeenCalled();
+    expect(controller.submitFollowUp).not.toHaveBeenCalled();
+    expect(outcome).toEqual({
+      kind: 'attachment',
+      sessionId: 'session-123',
+      fileName: 'spec.md',
+      contentType: 'text/markdown',
+      sizeBytes: 1024,
+      hasExtractedText: true
+    });
+  });
+
+  it('auto-attaches escaped-space file paths and submits remaining text', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agon-shell-engine-'));
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, 'brief v2.md');
+    await fs.writeFile(filePath, '# brief', 'utf-8');
+    const escapedPath = filePath.replace(/ /g, '\\ ');
+
+    const outcome = await engine.handleInput(`${escapedPath} summarize key risks`);
+
+    expect(controller.attachDocument).toHaveBeenCalledWith(filePath);
+    expect(controller.submitFollowUp).toHaveBeenCalledWith('summarize key risks');
+    expect(outcome).toEqual({
+      kind: 'follow-up',
+      sessionId: 'session-123',
+      status: 'active',
+      phase: 'Clarification',
+      response: {
+        agentId: 'moderator',
+        message: 'Next question'
+      }
+    });
+  });
+
+  it('returns a friendly message when a path-like input file does not exist', async () => {
+    const outcome = await engine.handleInput('/tmp/agon-shell-engine-missing-file.pdf');
+
+    expect(outcome).toEqual({ kind: 'noop' });
+    expect(controller.attachDocument).not.toHaveBeenCalled();
+    expect(controller.startIdea).not.toHaveBeenCalled();
+    expect(controller.submitFollowUp).not.toHaveBeenCalled();
+    expect(print).toHaveBeenCalledWith('File not found: /tmp/agon-shell-engine-missing-file.pdf');
   });
 
   it('runs /update --check through updater callback', async () => {

--- a/cli/test/shell/parser.test.ts
+++ b/cli/test/shell/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractInlineAttach, parseShellInput } from '../../src/shell/parser.js';
+import { extractImplicitAttach, extractInlineAttach, parseShellInput } from '../../src/shell/parser.js';
 
 describe('shell parser', () => {
   it('parses plain input', () => {
@@ -33,6 +33,13 @@ describe('shell parser', () => {
     expect(parseShellInput('help')).toEqual({
       type: 'plain',
       text: 'help'
+    });
+  });
+
+  it('treats absolute path-like input as plain text (not unknown slash command)', () => {
+    expect(parseShellInput('/Users/simonholmes/docs/spec.md')).toEqual({
+      type: 'plain',
+      text: '/Users/simonholmes/docs/spec.md'
     });
   });
 
@@ -281,5 +288,33 @@ describe('shell parser', () => {
       type: 'error',
       message: 'Usage: /attach <file-path>'
     });
+  });
+
+  it('extracts implicit attach from a path-only input', () => {
+    expect(extractImplicitAttach('/Users/simonholmes/docs/spec.md')).toEqual({
+      type: 'attach',
+      path: '/Users/simonholmes/docs/spec.md',
+      remainingText: ''
+    });
+  });
+
+  it('extracts implicit attach from path followed by message', () => {
+    expect(extractImplicitAttach('/Users/simonholmes/docs/spec.md summarize key points')).toEqual({
+      type: 'attach',
+      path: '/Users/simonholmes/docs/spec.md',
+      remainingText: 'summarize key points'
+    });
+  });
+
+  it('extracts implicit attach from escaped-space path tokens', () => {
+    expect(extractImplicitAttach('/Users/simonholmes/My\\ Documents/brief\\ v2.pdf please review')).toEqual({
+      type: 'attach',
+      path: '/Users/simonholmes/My Documents/brief v2.pdf',
+      remainingText: 'please review'
+    });
+  });
+
+  it('does not treat non-path plain text as implicit attach', () => {
+    expect(extractImplicitAttach('Please summarize this')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- support path-first file attach behavior directly from plain input (no `/attach` prefix required)
- accept escaped-space paths (common drag/drop terminal behavior)
- allow `path + message` in one input: attach first, then send trailing message
- show clearer shell guidance for paste/drag path usage
- add parser and engine coverage for success and failure scenarios
- add a changeset entry

## Why
Users should be able to attach files with minimal friction by pasting or dragging a local path directly into the shell input, while preserving existing `/attach` behavior.

## Validation
- `npm run build`
- `npx vitest run --dir test`
- pre-commit full suite (CLI + backend) passed

Closes #165
Part of #173