### PR TITLE
fix(cli+backend): explicit update relaunch, deterministic direct-answer routing, and image extraction hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
   - [Frontend (Next.js)](#frontend-nextjs)
 - [Testing and Quality](#testing--quality)
   - [Running Tests](#running-tests)
+  - [Pre-Merge Validation Protocol](#pre-merge-validation-protocol)
 - [CLI Release Process](#cli-release-process)
 - [Architecture Documentation](#architecture-documentation)
 - [Current Status](#current-status-march-2026)
@@ -252,7 +253,7 @@ Notes:
 - `/update` runs the same update flow from inside an active shell session.
 - By default, Agon CLI connects to the hosted backend endpoint (no manual `apiUrl` setup required for end users).
 - Endpoint override precedence is: `AGON_API_URL` (explicit runtime override), then `AGON_HOSTED_API_URL`, then `AGON_API_HOSTNAME` as `https://<hostname>`, then legacy fallback.
-- After successful in-shell update, your current session remains usable; restart later to run the newly installed runtime.
+- After successful in-shell update, exit the shell and start `agon` again to run the newly installed runtime.
 - On startup, Agon checks npm and alerts when a newer stable version is available.
 - `/attach` accepts only a file path. Upload first, then send your message as a separate prompt.
 
@@ -790,6 +791,80 @@ dotnet test backend/tests/Agon.Domain.Tests
 # CLI tests with coverage
 cd cli && npm run test:coverage
 ```
+
+### Pre-Merge Validation Protocol
+[Back to top](#top)
+
+Use this exact checklist before merging PRs that touch CLI and backend behavior.
+
+Important local-config note:
+- `cli/.agonrc` is your local shell config (for example `apiUrl`, friction, research toggle).
+- It is intentionally gitignored and should not be committed.
+- You can still test locally with it; not committing it does not affect your local runs.
+
+#### Track A — CLI behavior against deployed backend
+
+1. Point CLI to deployed environment:
+   ```bash
+   agon
+   /set apiUrl https://api-dev.agon-agents.org
+   /params
+   ```
+2. Validate `/update` message clarity:
+   ```bash
+   /update --check
+   /update
+   ```
+   Expected:
+   - update result is shown
+   - explicit instruction to exit and restart `agon` to use new runtime
+3. Validate moderator routing (no unnecessary full debate):
+   - Ask a short direct question: `What is DNS?`
+   - Ask a short utility prompt without a question mark: `Today's weather for AB31 5UQ`
+   - Run `/status`
+   Expected:
+   - direct answer from moderator
+   - no transition into `AnalysisRound` for this short direct question
+   - response is concise and does not expand into debate-style framework sections
+4. Validate post-delivery assistant simplicity:
+   - Complete one debate flow and then ask a simple follow-up: `What do DNS record types do?`
+   Expected:
+   - answer is direct and concise
+   - no unnecessary template-style framing
+5. Validate attachment image path:
+   - Drag/drop or paste an image path into shell, then ask: `Analyze this image.`
+   Expected:
+   - if vision extraction is configured: answer references image content
+   - if not configured: explicit warning about backend vision extraction configuration
+
+#### Track B — backend fix validation locally
+
+1. Start local dependencies and backend:
+   ```bash
+   cd backend
+   docker compose up -d postgres redis azurite
+   dotnet run --project src/Agon.Api/Agon.Api.csproj
+   ```
+2. In a second shell, point CLI to local backend and run checks:
+   ```bash
+   agon
+   /set apiUrl http://localhost:5000
+   /params
+   ```
+3. Run targeted automated tests before PR merge:
+   ```bash
+   # CLI tests
+   npm --prefix cli test
+
+   # Backend orchestration + extraction tests
+   dotnet test backend/tests/Agon.Application.Tests/Agon.Application.Tests.csproj --filter "FullyQualifiedName~Orchestration"
+   dotnet test backend/tests/Agon.Infrastructure.Tests/Agon.Infrastructure.Tests.csproj --filter "FullyQualifiedName~AttachmentTextExtractor"
+   ```
+4. Run full suite when changing shared flows:
+   ```bash
+   dotnet test backend/Agon.sln --verbosity minimal
+   npm --prefix cli test
+   ```
 
 ---
 

--- a/backend/src/Agon.Api/Configuration/AttachmentProcessingConfiguration.cs
+++ b/backend/src/Agon.Api/Configuration/AttachmentProcessingConfiguration.cs
@@ -28,6 +28,7 @@ public sealed class OpenAiVisionProcessingConfiguration
 {
     public bool Enabled { get; set; } = true;
     public string Model { get; set; } = "gpt-4o-mini";
+    public string FallbackModel { get; set; } = string.Empty;
     public int MaxTokens { get; set; } = 1200;
     public string Detail { get; set; } = "auto";
     public int MaxImageBytes { get; set; } = 6291456;

--- a/backend/src/Agon.Api/Program.cs
+++ b/backend/src/Agon.Api/Program.cs
@@ -75,7 +75,14 @@ llmConfig.Google.ApiKey = ReplaceEnvVars(llmConfig.Google.ApiKey);
 llmConfig.DeepSeek.ApiKey = ReplaceEnvVars(llmConfig.DeepSeek.ApiKey);
 attachmentProcessingConfig.DocumentIntelligence.Endpoint = ReplaceEnvVars(attachmentProcessingConfig.DocumentIntelligence.Endpoint);
 attachmentProcessingConfig.DocumentIntelligence.ApiKey = ReplaceEnvVars(attachmentProcessingConfig.DocumentIntelligence.ApiKey);
+attachmentProcessingConfig.OpenAiVision.FallbackModel = ReplaceEnvVars(attachmentProcessingConfig.OpenAiVision.FallbackModel);
 storageConfig.AttachmentBlobServiceUri = ReplaceEnvVars(storageConfig.AttachmentBlobServiceUri);
+
+llmConfig.OpenAI.ApiKey = NormalizeSecretValue(llmConfig.OpenAI.ApiKey);
+llmConfig.Anthropic.ApiKey = NormalizeSecretValue(llmConfig.Anthropic.ApiKey);
+llmConfig.Google.ApiKey = NormalizeSecretValue(llmConfig.Google.ApiKey);
+llmConfig.DeepSeek.ApiKey = NormalizeSecretValue(llmConfig.DeepSeek.ApiKey);
+attachmentProcessingConfig.DocumentIntelligence.ApiKey = NormalizeSecretValue(attachmentProcessingConfig.DocumentIntelligence.ApiKey);
 
 builder.Services.AddSingleton(llmConfig);
 builder.Services.AddSingleton(agonConfig);
@@ -98,6 +105,9 @@ builder.Services.AddSingleton(new AttachmentExtractionOptions
         Enabled = attachmentProcessingConfig.OpenAiVision.Enabled,
         ApiKey = llmConfig.OpenAI.ApiKey,
         Model = attachmentProcessingConfig.OpenAiVision.Model,
+        FallbackModel = string.IsNullOrWhiteSpace(attachmentProcessingConfig.OpenAiVision.FallbackModel)
+            ? llmConfig.OpenAI.Model
+            : attachmentProcessingConfig.OpenAiVision.FallbackModel,
         MaxTokens = attachmentProcessingConfig.OpenAiVision.MaxTokens,
         Detail = attachmentProcessingConfig.OpenAiVision.Detail,
         MaxImageBytes = attachmentProcessingConfig.OpenAiVision.MaxImageBytes
@@ -532,6 +542,16 @@ static bool IsConfiguredValue(string? value)
 
     var trimmed = value.Trim();
     return !(trimmed.StartsWith("${", StringComparison.Ordinal) && trimmed.EndsWith("}", StringComparison.Ordinal));
+}
+
+static string NormalizeSecretValue(string? value)
+{
+    if (!IsConfiguredValue(value))
+    {
+        return string.Empty;
+    }
+
+    return value!.Trim();
 }
 
 static string ConfigureAttachmentStorage(

--- a/backend/src/Agon.Api/appsettings.json
+++ b/backend/src/Agon.Api/appsettings.json
@@ -51,6 +51,7 @@
     "OpenAiVision": {
       "Enabled": true,
       "Model": "gpt-4o-mini",
+      "FallbackModel": "",
       "MaxTokens": 1200,
       "Detail": "auto",
       "MaxImageBytes": 6291456

--- a/backend/src/Agon.Application/Orchestration/AgentRunner.cs
+++ b/backend/src/Agon.Application/Orchestration/AgentRunner.cs
@@ -32,9 +32,11 @@ public sealed class AgentRunner : IAgentRunner
         If you cannot make a valid patch, output an empty ops array with valid meta.
         """;
     private const string ModeratorDirectAnswerDirective = """
-        The latest user input is a simple/meta question about Agon itself.
+        The latest user input should be handled as a direct answer path.
         Do NOT ask clarification questions.
-        Provide a direct, concise, user-facing explanation.
+        Answer only the user's latest request with a direct, concise explanation.
+        Do NOT include Agon workflow/process context unless explicitly asked.
+        For straightforward factual or utility requests, keep output plain and minimal.
         First line in MESSAGE must be exactly: STATUS: DIRECT_ANSWER
         PATCH must be valid JSON with empty ops and correct moderator meta.
         """;
@@ -54,21 +56,6 @@ public sealed class AgentRunner : IAgentRunner
     private static readonly Regex ModeratorRouteRegex = new(
         @"^\s*route\s*[:=]\s*(DIRECT_ANSWER|FULL_DEBATE)\b",
         RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex AnalysisIntentRegex = new(
-        @"\b(prd|product requirements?|debate brief|architecture|roadmap|mvp|spec(?:ification)?|analysis|analy[sz]e|evaluate|compare|implementation|implement|build|design|tech stack|user stor(?:y|ies))\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex SimpleMetaQueryRegex = new(
-        @"\b(what can you do|how can you help|who are you|what is agon|internal setup|your setup|how do you work|capabilities|command(?:s)?)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex SelfReferenceRegex = new(
-        @"\b(agon|you|your|this assistant|this tool|this cli)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex SystemMetaTopicRegex = new(
-        @"\b(agent(?:s)?|llm(?:s)?|model(?:s)?|internal|setup|architecture|capabilit(?:y|ies)|command(?:s)?|work(?:s|ing)?|help)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex QuestionLeadRegex = new(
-        @"^\s*(how|what|who|can|could|would|do|does|is|are|where|when)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly IReadOnlyList<ICouncilAgent> _agents;
     private readonly ITruthMapRepository _truthMapRepository;
@@ -118,7 +105,7 @@ public sealed class AgentRunner : IAgentRunner
             false, // Research tools not used during clarification
             state.Attachments);
 
-        var shouldRunIntentRouter = ShouldRunIntentRouter(state);
+        var shouldRunIntentRouter = ModeratorRoutingClassifier.ShouldRunIntentRouter(state);
         var routeDecision = await DetermineModeratorRouteAsync(
             moderator,
             context,
@@ -216,6 +203,14 @@ public sealed class AgentRunner : IAgentRunner
         bool shouldRunIntentRouter,
         CancellationToken cancellationToken)
     {
+        if (ModeratorRoutingClassifier.ShouldForceDirectAnswer(state))
+        {
+            _logger?.LogInformation(
+                "Deterministic moderator classifier selected DIRECT_ANSWER for session {SessionId}.",
+                state.SessionId);
+            return new ModeratorRouteDecision(true, "deterministic");
+        }
+
         if (!shouldRunIntentRouter)
         {
             return new ModeratorRouteDecision(false, "router_not_run");
@@ -251,7 +246,7 @@ public sealed class AgentRunner : IAgentRunner
                 state.SessionId);
         }
 
-        var fallback = ShouldHandleAsSimpleMetaQuery(state);
+        var fallback = ModeratorRoutingClassifier.ShouldForceDirectAnswer(state);
         _logger?.LogInformation(
             "Moderator intent router fell back to deterministic heuristics (directAnswer={DirectAnswer}) for session {SessionId}.",
             fallback,
@@ -383,76 +378,6 @@ public sealed class AgentRunner : IAgentRunner
         }
 
         return ModeratorRoute.Unknown;
-    }
-
-    private static bool ShouldRunIntentRouter(SessionState state)
-    {
-        var latestInput = GetLatestUserInput(state);
-        if (string.IsNullOrWhiteSpace(latestInput))
-        {
-            return false;
-        }
-
-        var trimmed = latestInput.Trim();
-        if (trimmed.Length is < 4 or > 600)
-        {
-            return false;
-        }
-
-        return trimmed.Contains('?') || QuestionLeadRegex.IsMatch(trimmed);
-    }
-
-    private static bool ShouldHandleAsSimpleMetaQuery(SessionState state)
-    {
-        var latestInput = GetLatestUserInput(state);
-        if (string.IsNullOrWhiteSpace(latestInput))
-        {
-            return false;
-        }
-
-        return LooksLikeSimpleMetaQuery(latestInput);
-    }
-
-    private static string GetLatestUserInput(SessionState state)
-    {
-        if (state.UserMessages.Count > 0)
-        {
-            return state.UserMessages[^1].Content;
-        }
-
-        return state.Idea ?? string.Empty;
-    }
-
-    private static bool LooksLikeSimpleMetaQuery(string input)
-    {
-        var trimmed = input.Trim();
-        if (trimmed.Length is < 4 or > 280)
-        {
-            return false;
-        }
-
-        var looksLikeQuestion = trimmed.Contains('?') || QuestionLeadRegex.IsMatch(trimmed);
-        if (!looksLikeQuestion)
-        {
-            return false;
-        }
-
-        if (SimpleMetaQueryRegex.IsMatch(trimmed))
-        {
-            return true;
-        }
-
-        var selfReferential = SelfReferenceRegex.IsMatch(trimmed);
-        var systemTopic = SystemMetaTopicRegex.IsMatch(trimmed);
-        var strongProjectSignal = AnalysisIntentRegex.IsMatch(trimmed)
-            && !selfReferential;
-
-        if (strongProjectSignal)
-        {
-            return false;
-        }
-
-        return selfReferential && systemTopic;
     }
 
     /// <summary>

--- a/backend/src/Agon.Application/Orchestration/ModeratorRoutingClassifier.cs
+++ b/backend/src/Agon.Application/Orchestration/ModeratorRoutingClassifier.cs
@@ -1,0 +1,122 @@
+using Agon.Application.Models;
+using System.Text.RegularExpressions;
+
+namespace Agon.Application.Orchestration;
+
+internal static class ModeratorRoutingClassifier
+{
+    private static readonly Regex FullDebateIntentRegex = new(
+        @"\b(prd|product requirements?|debate brief|architecture|roadmap|mvp|spec(?:ification)?|tech stack|user stor(?:y|ies)|risk(?:s)?|assumption(?:s)?|implementation(?: plan)?|migration|refactor|go[- ]?to[- ]?market)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex SimpleMetaQueryRegex = new(
+        @"\b(what can you do|how can you help|who are you|what is agon|internal setup|your setup|how do you work|capabilities|command(?:s)?)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex SelfReferenceRegex = new(
+        @"\b(agon|you|your|this assistant|this tool|this cli)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex SystemMetaTopicRegex = new(
+        @"\b(agent(?:s)?|llm(?:s)?|model(?:s)?|internal|setup|architecture|capabilit(?:y|ies)|command(?:s)?|work(?:s|ing)?|help)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex QuestionLeadRegex = new(
+        @"^\s*(how|what|who|can|could|would|do|does|is|are|where|when)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex UtilityImperativeLeadRegex = new(
+        @"^\s*(give|show|tell|explain|describe|define|check|summari[sz]e|compare|help\s+me\s+understand|today(?:'s)?|current)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex UtilityTopicRegex = new(
+        @"\b(weather|forecast|temperature|rain|wind|postcode|dns|domain|record(?:\s+types?)?|a/aaaa|cname|mx|txt|http|https|ssl|tls|certificate|hostname|ip(?:v4|v6)?|status\s*code|timezone|utc)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex WordRegex = new(@"\b[\w'-]+\b", RegexOptions.Compiled);
+    private static readonly Regex AttachmentDirectActionRegex = new(
+        @"\b(describe|summari[sz]e|caption|transcribe|read|extract|analy[sz]e)\b.*\b(image|photo|picture|screenshot|scan|document|file|pdf|attachment)\b|\b(this|attached)\s+(image|document|file|pdf|attachment)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public static bool ShouldRunIntentRouter(SessionState state)
+    {
+        var latestInput = GetLatestUserInput(state);
+        if (string.IsNullOrWhiteSpace(latestInput))
+        {
+            return false;
+        }
+
+        var trimmed = latestInput.Trim();
+        if (trimmed.Length is < 4 or > 600)
+        {
+            return false;
+        }
+
+        if (ShouldForceDirectAnswer(state))
+        {
+            return false;
+        }
+
+        return LooksLikeQuestion(trimmed);
+    }
+
+    public static bool ShouldForceDirectAnswer(SessionState state)
+    {
+        var latestInput = GetLatestUserInput(state);
+        if (string.IsNullOrWhiteSpace(latestInput))
+        {
+            return false;
+        }
+
+        return LooksLikeSimpleDirectQuery(latestInput, state.Attachments.Count > 0);
+    }
+
+    private static string GetLatestUserInput(SessionState state)
+    {
+        if (state.UserMessages.Count > 0)
+        {
+            return state.UserMessages[^1].Content;
+        }
+
+        return state.Idea ?? string.Empty;
+    }
+
+    private static bool LooksLikeSimpleDirectQuery(string input, bool hasAttachments)
+    {
+        var trimmed = input.Trim();
+        if (trimmed.Length is < 4 or > 280)
+        {
+            return false;
+        }
+
+        var attachmentImperative = hasAttachments && AttachmentDirectActionRegex.IsMatch(trimmed);
+        var utilityImperative = LooksLikeUtilityImperative(trimmed);
+        if (!LooksLikeQuestion(trimmed) && !attachmentImperative && !utilityImperative)
+        {
+            return false;
+        }
+
+        var wordCount = WordRegex.Matches(trimmed).Count;
+        if (wordCount > 45)
+        {
+            return false;
+        }
+
+        if (SimpleMetaQueryRegex.IsMatch(trimmed))
+        {
+            return true;
+        }
+
+        var selfReferential = SelfReferenceRegex.IsMatch(trimmed);
+        var systemTopic = SystemMetaTopicRegex.IsMatch(trimmed);
+        if (selfReferential && systemTopic)
+        {
+            return true;
+        }
+
+        return !FullDebateIntentRegex.IsMatch(trimmed);
+    }
+
+    private static bool LooksLikeQuestion(string input)
+    {
+        return input.Contains('?') || QuestionLeadRegex.IsMatch(input);
+    }
+
+    private static bool LooksLikeUtilityImperative(string input)
+    {
+        return UtilityImperativeLeadRegex.IsMatch(input) && UtilityTopicRegex.IsMatch(input);
+    }
+}

--- a/backend/src/Agon.Application/Orchestration/Orchestrator.cs
+++ b/backend/src/Agon.Application/Orchestration/Orchestrator.cs
@@ -24,21 +24,6 @@ public sealed class Orchestrator : IOrchestrator
     private static readonly Regex ModeratorStatusRegex = new(
         @"^\s*(?:status|clarification_status)\s*[:=]\s*(DIRECT_ANSWER|READY|NEEDS_INFO)\b",
         RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex AnalysisIntentRegex = new(
-        @"\b(prd|product requirements?|debate brief|architecture|roadmap|mvp|spec(?:ification)?|analysis|analy[sz]e|evaluate|compare|implementation|implement|build|design|tech stack|user stor(?:y|ies))\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex SimpleMetaQueryRegex = new(
-        @"\b(what can you do|how can you help|who are you|what is agon|internal setup|your setup|how do you work|capabilities|command(?:s)?)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex SelfReferenceRegex = new(
-        @"\b(agon|you|your|this assistant|this tool|this cli)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex SystemMetaTopicRegex = new(
-        @"\b(agent(?:s)?|llm(?:s)?|model(?:s)?|internal|setup|architecture|capabilit(?:y|ies)|command(?:s)?|work(?:s|ing)?|help)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-    private static readonly Regex QuestionLeadRegex = new(
-        @"^\s*(how|what|who|can|could|would|do|does|is|are|where|when)\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private readonly IAgentRunner _agentRunner;
     private readonly ISessionService _sessionService;
@@ -93,12 +78,12 @@ public sealed class Orchestrator : IOrchestrator
             && decision.Status == ModeratorDecisionStatus.Ready;
         var shouldTreatReadyAsDirectAnswer =
             decision.Status == ModeratorDecisionStatus.Ready
-            && ShouldHandleAsSimpleMetaQuery(state);
+            && ModeratorRoutingClassifier.ShouldForceDirectAnswer(state);
 
         if (shouldTreatReadyAsDirectAnswer)
         {
             _logger?.LogInformation(
-                "Session {SessionId}: Moderator returned READY for a simple/meta query. Treating as DIRECT_ANSWER and suppressing debate chain.",
+                "Session {SessionId}: Moderator returned READY for a direct-answer query. Treating as DIRECT_ANSWER and suppressing debate chain.",
                 state.SessionId);
             decision = new ModeratorDecision(ModeratorDecisionStatus.DirectAnswer);
         }
@@ -227,59 +212,6 @@ public sealed class Orchestrator : IOrchestrator
         }
 
         return new ModeratorDecision(ModeratorDecisionStatus.Unknown);
-    }
-
-    private static bool ShouldHandleAsSimpleMetaQuery(SessionState state)
-    {
-        var latestInput = GetLatestUserInput(state);
-        if (string.IsNullOrWhiteSpace(latestInput))
-        {
-            return false;
-        }
-
-        return LooksLikeSimpleMetaQuery(latestInput);
-    }
-
-    private static string GetLatestUserInput(SessionState state)
-    {
-        if (state.UserMessages.Count > 0)
-        {
-            return state.UserMessages[^1].Content;
-        }
-
-        return state.Idea ?? string.Empty;
-    }
-
-    private static bool LooksLikeSimpleMetaQuery(string input)
-    {
-        var trimmed = input.Trim();
-        if (trimmed.Length is < 4 or > 280)
-        {
-            return false;
-        }
-
-        var looksLikeQuestion = trimmed.Contains('?') || QuestionLeadRegex.IsMatch(trimmed);
-        if (!looksLikeQuestion)
-        {
-            return false;
-        }
-
-        if (SimpleMetaQueryRegex.IsMatch(trimmed))
-        {
-            return true;
-        }
-
-        var selfReferential = SelfReferenceRegex.IsMatch(trimmed);
-        var systemTopic = SystemMetaTopicRegex.IsMatch(trimmed);
-        var strongProjectSignal = AnalysisIntentRegex.IsMatch(trimmed)
-            && !selfReferential;
-
-        if (strongProjectSignal)
-        {
-            return false;
-        }
-
-        return selfReferential && systemTopic;
     }
 
     private enum ModeratorDecisionStatus

--- a/backend/src/Agon.Domain/Agents/AgentSystemPrompts.cs
+++ b/backend/src/Agon.Domain/Agents/AgentSystemPrompts.cs
@@ -21,8 +21,8 @@ INPUTS PROVIDED:
 - User Responses (if any - shows previous user answers)
 
 CRITICAL RULES:
-1. If the user request is a SIMPLE/META question about Agon itself (capabilities, commands, high-level internal setup, ""how can you help?""), and NOT a project/debate request, answer directly with STATUS: DIRECT_ANSWER.
-2. In DIRECT_ANSWER mode, do not ask clarifying questions, do not output READY, and do not trigger debate-chain framing.
+1. If the latest user request is a SIMPLE direct-answer request (Agon meta question, factual question, or utility question) and NOT project/debate work, answer directly with STATUS: DIRECT_ANSWER.
+2. In DIRECT_ANSWER mode, do not ask clarifying questions, do not output READY, and do not trigger debate-chain framing. Answer only the asked question in concise plain language.
 3. For project/debate requests: on the FIRST ROUND (round 0, when User Responses is empty or only contains the initial idea), you MUST ask at least one clarifying question. DO NOT output READY on round 0.
 4. If you ask ANY clarifying questions in your MESSAGE, you MUST NOT output READY in that same response.
 5. Ask ADAPTIVE questions, not a fixed template. Focus on the highest-impact unknowns for execution.
@@ -349,9 +349,9 @@ INPUTS PROVIDED:
 
 INSTRUCTIONS:
 1) Treat the latest user message as the active request.
-2) Provide a direct, complete answer in Markdown.
+2) Provide a direct answer in Markdown focused on the latest request.
 3) If the user asks for modifications, return a revised version directly in the response.
-4) Keep the response practical and actionable.
+4) Keep the response practical and concise. Avoid unnecessary frameworks, process narration, or multi-section templates unless the user explicitly asks for them.
 5) Do not ask unnecessary clarification unless the request is ambiguous or conflicting.
 6) Do not emit Truth Map patches in this mode.
 

--- a/backend/src/Agon.Infrastructure/Attachments/AttachmentExtractionOptions.cs
+++ b/backend/src/Agon.Infrastructure/Attachments/AttachmentExtractionOptions.cs
@@ -27,6 +27,7 @@ public sealed class OpenAiVisionExtractionOptions
     public bool Enabled { get; set; } = true;
     public string ApiKey { get; set; } = string.Empty;
     public string Model { get; set; } = "gpt-4o-mini";
+    public string FallbackModel { get; set; } = string.Empty;
     public int MaxTokens { get; set; } = 1200;
     public string Detail { get; set; } = "auto";
     public int MaxImageBytes { get; set; } = 6 * 1024 * 1024;

--- a/backend/src/Agon.Infrastructure/Attachments/AttachmentTextExtractor.cs
+++ b/backend/src/Agon.Infrastructure/Attachments/AttachmentTextExtractor.cs
@@ -104,7 +104,13 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
         if (IsImage(fileName, normalizedContentType))
         {
             var visionResult = await ExtractWithOpenAiVisionAsync(content, normalizedContentType, cancellationToken);
-            return NormalizeText(visionResult);
+            if (!string.IsNullOrWhiteSpace(visionResult))
+            {
+                return NormalizeText(visionResult);
+            }
+
+            var imageOcrResult = await ExtractWithDocumentIntelligenceAsync(content, cancellationToken);
+            return NormalizeText(imageOcrResult);
         }
 
         if (IsDocument(fileName, normalizedContentType))
@@ -240,7 +246,7 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
         string normalizedContentType,
         CancellationToken cancellationToken)
     {
-        if (!_options.OpenAiVision.Enabled || string.IsNullOrWhiteSpace(_options.OpenAiVision.ApiKey))
+        if (!_options.OpenAiVision.Enabled || !IsConfiguredSecret(_options.OpenAiVision.ApiKey))
         {
             return null;
         }
@@ -253,10 +259,58 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
             return null;
         }
 
+        var primaryModel = string.IsNullOrWhiteSpace(_options.OpenAiVision.Model)
+            ? "gpt-4o-mini"
+            : _options.OpenAiVision.Model.Trim();
+        var fallbackModel = string.IsNullOrWhiteSpace(_options.OpenAiVision.FallbackModel)
+            ? string.Empty
+            : _options.OpenAiVision.FallbackModel.Trim();
+
+        var primaryAttempt = await TryExtractWithOpenAiModelAsync(
+            content,
+            normalizedContentType,
+            primaryModel,
+            cancellationToken);
+        if (!string.IsNullOrWhiteSpace(primaryAttempt.Text))
+        {
+            return primaryAttempt.Text;
+        }
+
+        var shouldTryFallback =
+            !string.IsNullOrWhiteSpace(fallbackModel)
+            && !string.Equals(primaryModel, fallbackModel, StringComparison.OrdinalIgnoreCase)
+            && primaryAttempt.StatusCode is HttpStatusCode.BadRequest or HttpStatusCode.NotFound;
+
+        if (!shouldTryFallback)
+        {
+            return null;
+        }
+
+        _logger.LogInformation(
+            "Retrying OpenAI vision extraction with fallback model {FallbackModel} after primary model {PrimaryModel} failed with status {StatusCode}.",
+            fallbackModel,
+            primaryModel,
+            (int)primaryAttempt.StatusCode!.Value);
+
+        var fallbackAttempt = await TryExtractWithOpenAiModelAsync(
+            content,
+            normalizedContentType,
+            fallbackModel,
+            cancellationToken);
+
+        return fallbackAttempt.Text;
+    }
+
+    private async Task<OpenAiVisionAttemptResult> TryExtractWithOpenAiModelAsync(
+        byte[] content,
+        string normalizedContentType,
+        string model,
+        CancellationToken cancellationToken)
+    {
         var dataUrl = $"data:{(string.IsNullOrWhiteSpace(normalizedContentType) ? "application/octet-stream" : normalizedContentType)};base64,{Convert.ToBase64String(content)}";
         var requestPayload = new
         {
-            model = string.IsNullOrWhiteSpace(_options.OpenAiVision.Model) ? "gpt-4o-mini" : _options.OpenAiVision.Model,
+            model,
             temperature = 0,
             max_tokens = Math.Max(256, _options.OpenAiVision.MaxTokens),
             messages = new object[]
@@ -303,13 +357,14 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
         if (!response.IsSuccessStatusCode)
         {
             _logger.LogWarning(
-                "OpenAI vision extraction failed. Status={StatusCode}, Payload={Payload}",
+                "OpenAI vision extraction failed for model {Model}. Status={StatusCode}, Payload={Payload}",
+                model,
                 (int)response.StatusCode,
                 Truncate(payload, 600));
-            return null;
+            return new OpenAiVisionAttemptResult(null, response.StatusCode);
         }
 
-        return ParseOpenAiContent(payload);
+        return new OpenAiVisionAttemptResult(ParseOpenAiContent(payload), response.StatusCode);
     }
 
     private static string NormalizeContentType(string contentType)
@@ -320,6 +375,17 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
         }
 
         return contentType.Split(';')[0].Trim();
+    }
+
+    private static bool IsConfiguredSecret(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var trimmed = value.Trim();
+        return !(trimmed.StartsWith("${", StringComparison.Ordinal) && trimmed.EndsWith("}", StringComparison.Ordinal));
     }
 
     private static bool IsImage(string fileName, string contentType)
@@ -417,7 +483,7 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
 
             if (!message.TryGetProperty("content", out var content))
             {
-                return null;
+                return ParseResponsesApiContent(document.RootElement);
             }
 
             if (content.ValueKind == JsonValueKind.String)
@@ -428,24 +494,78 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
             if (content.ValueKind == JsonValueKind.Array)
             {
                 var parts = content.EnumerateArray()
-                    .Where(item => item.TryGetProperty("type", out var type) &&
-                                   type.ValueKind == JsonValueKind.String &&
-                                   string.Equals(type.GetString(), "text", StringComparison.OrdinalIgnoreCase) &&
-                                   item.TryGetProperty("text", out var textProp) &&
-                                   textProp.ValueKind == JsonValueKind.String)
-                    .Select(item => item.GetProperty("text").GetString())
+                    .Select(ExtractContentText)
                     .Where(text => !string.IsNullOrWhiteSpace(text))
                     .OfType<string>();
 
                 return string.Join("\n", parts);
             }
 
-            return null;
+            return ParseResponsesApiContent(document.RootElement);
         }
         catch
         {
             return null;
         }
+    }
+
+    private static string? ParseResponsesApiContent(JsonElement root)
+    {
+        if (!root.TryGetProperty("output", out var output) || output.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var segments = new List<string>();
+        foreach (var outputItem in output.EnumerateArray())
+        {
+            if (!outputItem.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            foreach (var contentItem in content.EnumerateArray())
+            {
+                var text = ExtractContentText(contentItem);
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    segments.Add(text);
+                }
+            }
+        }
+
+        return segments.Count == 0 ? null : string.Join("\n", segments);
+    }
+
+    private static string? ExtractContentText(JsonElement contentItem)
+    {
+        if (contentItem.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        if (contentItem.TryGetProperty("text", out var textProp))
+        {
+            if (textProp.ValueKind == JsonValueKind.String)
+            {
+                return textProp.GetString();
+            }
+
+            if (textProp.ValueKind == JsonValueKind.Object &&
+                textProp.TryGetProperty("value", out var valueProp) &&
+                valueProp.ValueKind == JsonValueKind.String)
+            {
+                return valueProp.GetString();
+            }
+        }
+
+        if (contentItem.TryGetProperty("content", out var contentProp) &&
+            contentProp.ValueKind == JsonValueKind.String)
+        {
+            return contentProp.GetString();
+        }
+
+        return null;
     }
 
     private static string? ParseDocumentIntelligenceStatus(string payload)
@@ -504,4 +624,8 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
             ? value
             : value[..maxLength] + "...";
     }
+
+    private readonly record struct OpenAiVisionAttemptResult(
+        string? Text,
+        HttpStatusCode? StatusCode);
 }

--- a/backend/tests/Agon.Application.Tests/Orchestration/AgentRunnerTests.cs
+++ b/backend/tests/Agon.Application.Tests/Orchestration/AgentRunnerTests.cs
@@ -638,7 +638,7 @@ public class AgentRunnerTests
     }
 
     [Fact]
-    public async Task RunModeratorAsync_SimpleMetaQuery_WithNeedsInfoFirst_ShouldRetryForDirectAnswer()
+    public async Task RunModeratorAsync_SimpleMetaQuery_ShouldUseDeterministicDirectAnswerPath()
     {
         // Arrange
         var repo = StubRepo();
@@ -649,13 +649,6 @@ public class AgentRunnerTests
         moderator.ModelProvider.Returns("fake/model");
         moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
             .Returns(
-                Task.FromResult(new AgentResponse(
-                    AgentId.Moderator,
-                    "ROUTE: DIRECT_ANSWER\nMeta/system question about how Agon works.",
-                    null,
-                    20,
-                    false,
-                    null)),
                 Task.FromResult(new AgentResponse(
                     AgentId.Moderator,
                     "STATUS: NEEDS_INFO\nWhat are you trying to build?",
@@ -679,16 +672,15 @@ public class AgentRunnerTests
         var response = await runner.RunModeratorAsync(state, CancellationToken.None);
 
         // Assert
-        await moderator.Received(3).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
-        capturedContexts.Should().HaveCount(3);
-        capturedContexts[0].MicroDirective.Should().Contain("ROUTE: DIRECT_ANSWER");
+        await moderator.Received(2).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(2);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
         capturedContexts[1].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
-        capturedContexts[2].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
         response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
     }
 
     [Fact]
-    public async Task RunModeratorAsync_InternalArchitectureQuestion_ShouldUseLlmRouterToForceDirectAnswer()
+    public async Task RunModeratorAsync_InternalArchitectureQuestion_ShouldUseDeterministicDirectAnswerPath()
     {
         // Arrange
         var repo = StubRepo();
@@ -699,13 +691,6 @@ public class AgentRunnerTests
         moderator.ModelProvider.Returns("fake/model");
         moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
             .Returns(
-                Task.FromResult(new AgentResponse(
-                    AgentId.Moderator,
-                    "ROUTE: DIRECT_ANSWER\nUser is asking about Agon internal architecture and models.",
-                    null,
-                    25,
-                    false,
-                    null)),
                 Task.FromResult(new AgentResponse(
                     AgentId.Moderator,
                     "STATUS: NEEDS_INFO\nPlease clarify your context.",
@@ -729,11 +714,147 @@ public class AgentRunnerTests
         var response = await runner.RunModeratorAsync(state, CancellationToken.None);
 
         // Assert
-        await moderator.Received(3).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
-        capturedContexts.Should().HaveCount(3);
-        capturedContexts[0].MicroDirective.Should().Contain("ROUTE: DIRECT_ANSWER");
+        await moderator.Received(2).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(2);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
         capturedContexts[1].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
-        capturedContexts[2].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
+        response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_ShortGeneralQuestion_ShouldUseDeterministicDirectAnswerPath()
+    {
+        // Arrange
+        var repo = StubRepo();
+        var capturedContexts = new List<AgentContext>();
+
+        var moderator = Substitute.For<ICouncilAgent>();
+        moderator.AgentId.Returns(AgentId.Moderator);
+        moderator.ModelProvider.Returns("fake/model");
+        moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new AgentResponse(
+                AgentId.Moderator,
+                "STATUS: DIRECT_ANSWER\nDNS maps hostnames to IP addresses.",
+                null,
+                60,
+                false,
+                null)));
+
+        var runner = BuildRunner([moderator], repo: repo);
+        var state = BuildSessionState(idea: "What is DNS?");
+        state.Phase = SessionPhase.Clarification;
+
+        // Act
+        var response = await runner.RunModeratorAsync(state, CancellationToken.None);
+
+        // Assert
+        await moderator.Received(1).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(1);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
+        response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_UtilityImperativeWithoutQuestionMark_ShouldUseDeterministicDirectAnswerPath()
+    {
+        // Arrange
+        var repo = StubRepo();
+        var capturedContexts = new List<AgentContext>();
+
+        var moderator = Substitute.For<ICouncilAgent>();
+        moderator.AgentId.Returns(AgentId.Moderator);
+        moderator.ModelProvider.Returns("fake/model");
+        moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new AgentResponse(
+                AgentId.Moderator,
+                "STATUS: DIRECT_ANSWER\nToday in AB31 5UQ, expect light rain and 9C.",
+                null,
+                60,
+                false,
+                null)));
+
+        var runner = BuildRunner([moderator], repo: repo);
+        var state = BuildSessionState(idea: "Today's weather for AB31 5UQ");
+        state.Phase = SessionPhase.Clarification;
+
+        // Act
+        var response = await runner.RunModeratorAsync(state, CancellationToken.None);
+
+        // Assert
+        await moderator.Received(1).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(1);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
+        response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_UtilityFollowUpMessage_ShouldUseLatestUserMessageForDeterministicDirectAnswerPath()
+    {
+        // Arrange
+        var repo = StubRepo();
+        var capturedContexts = new List<AgentContext>();
+
+        var moderator = Substitute.For<ICouncilAgent>();
+        moderator.AgentId.Returns(AgentId.Moderator);
+        moderator.ModelProvider.Returns("fake/model");
+        moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new AgentResponse(
+                AgentId.Moderator,
+                "STATUS: DIRECT_ANSWER\nDNS record types map hostnames and services.",
+                null,
+                60,
+                false,
+                null)));
+
+        var runner = BuildRunner([moderator], repo: repo);
+        var state = BuildSessionState(idea: "Create a full PRD for a new payments product");
+        state.Phase = SessionPhase.Clarification;
+        state.UserMessages.Add(new UserMessage(
+            "Explain DNS record types",
+            DateTimeOffset.UtcNow,
+            1));
+
+        // Act
+        var response = await runner.RunModeratorAsync(state, CancellationToken.None);
+
+        // Assert
+        await moderator.Received(1).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(1);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
+        response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_AttachmentImperativePrompt_ShouldUseDeterministicDirectAnswerPath()
+    {
+        // Arrange
+        var repo = StubRepo();
+        var capturedContexts = new List<AgentContext>();
+
+        var moderator = Substitute.For<ICouncilAgent>();
+        moderator.AgentId.Returns(AgentId.Moderator);
+        moderator.ModelProvider.Returns("fake/model");
+        moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new AgentResponse(
+                AgentId.Moderator,
+                "STATUS: DIRECT_ANSWER\nThis image appears to show a dashboard screenshot.",
+                null,
+                55,
+                false,
+                null)));
+
+        var runner = BuildRunner([moderator], repo: repo);
+        var state = BuildSessionState(idea: "Describe this image");
+        state.Phase = SessionPhase.Clarification;
+        state.Attachments.Add(BuildAttachment("mock-image.jpeg", "image/jpeg"));
+
+        // Act
+        var response = await runner.RunModeratorAsync(state, CancellationToken.None);
+
+        // Assert
+        await moderator.Received(1).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(1);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
         response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
     }
 
@@ -812,6 +933,22 @@ public class AgentRunnerTests
         var state = SessionState.Create(SessionId, Guid.Empty, idea, frictionLevel, false, EmptyMap());
         state.CurrentRound = round;
         return state;
+    }
+
+    private static SessionAttachment BuildAttachment(string fileName, string contentType)
+    {
+        return new SessionAttachment(
+            AttachmentId: Guid.NewGuid(),
+            SessionId: SessionId,
+            UserId: Guid.Empty,
+            FileName: fileName,
+            ContentType: contentType,
+            SizeBytes: 1024,
+            BlobName: $"blob/{fileName}",
+            BlobUri: $"https://example.invalid/{fileName}",
+            AccessUrl: $"https://example.invalid/access/{fileName}",
+            ExtractedText: null,
+            UploadedAt: DateTimeOffset.UtcNow);
     }
 
     private static ICouncilAgent BuildCapturingAgent(

--- a/backend/tests/Agon.Application.Tests/Orchestration/OrchestratorTests.cs
+++ b/backend/tests/Agon.Application.Tests/Orchestration/OrchestratorTests.cs
@@ -841,6 +841,135 @@ public class OrchestratorTests
     }
 
     [Fact]
+    public async Task RunModeratorAsync_WithReadyAndShortGeneralQuestion_ShouldSuppressDebateChain()
+    {
+        var runner = Substitute.For<IAgentRunner>();
+        var moderatorResponse = new AgentResponse(
+            AgentId.Moderator,
+            "STATUS: READY\nDNS maps hostnames to IP addresses.",
+            null,
+            80,
+            false,
+            null);
+
+        runner.RunModeratorAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(moderatorResponse));
+
+        var sessionService = StubSessionService();
+        var orchestrator = BuildOrchestrator(
+            runner: runner,
+            sessionService: sessionService);
+
+        var state = BuildState(SessionPhase.Clarification);
+        state.ClarificationRoundCount = 1;
+        state.UserMessages.Add(new UserMessage(
+            "What is DNS?",
+            DateTimeOffset.UtcNow,
+            1));
+
+        await orchestrator.RunModeratorAsync(state, CancellationToken.None);
+
+        state.ClarificationRoundCount.Should().Be(1);
+        await sessionService.DidNotReceive().AdvancePhaseAsync(
+            state,
+            SessionPhase.AnalysisRound,
+            Arg.Any<CancellationToken>());
+        await sessionService.DidNotReceive().RecordRoundSnapshotAsync(
+            state,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_WithReadyAndUtilityImperativeWithoutQuestionMark_ShouldSuppressDebateChain()
+    {
+        var runner = Substitute.For<IAgentRunner>();
+        var moderatorResponse = new AgentResponse(
+            AgentId.Moderator,
+            "STATUS: READY\nToday in AB31 5UQ, expect light rain and a high near 9C.",
+            null,
+            80,
+            false,
+            null);
+
+        runner.RunModeratorAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(moderatorResponse));
+
+        var sessionService = StubSessionService();
+        var orchestrator = BuildOrchestrator(
+            runner: runner,
+            sessionService: sessionService);
+
+        var state = BuildState(SessionPhase.Clarification);
+        state.ClarificationRoundCount = 1;
+        state.UserMessages.Add(new UserMessage(
+            "Today's weather for AB31 5UQ",
+            DateTimeOffset.UtcNow,
+            1));
+
+        await orchestrator.RunModeratorAsync(state, CancellationToken.None);
+
+        state.ClarificationRoundCount.Should().Be(1);
+        await sessionService.DidNotReceive().AdvancePhaseAsync(
+            state,
+            SessionPhase.AnalysisRound,
+            Arg.Any<CancellationToken>());
+        await sessionService.DidNotReceive().RecordRoundSnapshotAsync(
+            state,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_WithReadyAndAttachmentImperative_ShouldSuppressDebateChain()
+    {
+        var runner = Substitute.For<IAgentRunner>();
+        var moderatorResponse = new AgentResponse(
+            AgentId.Moderator,
+            "STATUS: READY\nImage description complete.",
+            null,
+            80,
+            false,
+            null);
+
+        runner.RunModeratorAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(moderatorResponse));
+
+        var sessionService = StubSessionService();
+        var orchestrator = BuildOrchestrator(
+            runner: runner,
+            sessionService: sessionService);
+
+        var state = BuildState(SessionPhase.Clarification);
+        state.ClarificationRoundCount = 1;
+        state.UserMessages.Add(new UserMessage(
+            "Describe this image",
+            DateTimeOffset.UtcNow,
+            1));
+        state.Attachments.Add(new SessionAttachment(
+            AttachmentId: Guid.NewGuid(),
+            SessionId: state.SessionId,
+            UserId: state.UserId,
+            FileName: "example.jpg",
+            ContentType: "image/jpeg",
+            SizeBytes: 1024,
+            BlobName: "blob/example.jpg",
+            BlobUri: "https://example.invalid/blob/example.jpg",
+            AccessUrl: "https://example.invalid/access/example.jpg",
+            ExtractedText: null,
+            UploadedAt: DateTimeOffset.UtcNow));
+
+        await orchestrator.RunModeratorAsync(state, CancellationToken.None);
+
+        state.ClarificationRoundCount.Should().Be(1);
+        await sessionService.DidNotReceive().AdvancePhaseAsync(
+            state,
+            SessionPhase.AnalysisRound,
+            Arg.Any<CancellationToken>());
+        await sessionService.DidNotReceive().RecordRoundSnapshotAsync(
+            state,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RunModeratorAsync_ReadyOnFirstRoundWithoutUserMessages_ShouldNotAdvance()
     {
         var runner = Substitute.For<IAgentRunner>();

--- a/backend/tests/Agon.Infrastructure.Tests/Attachments/AttachmentTextExtractorTests.cs
+++ b/backend/tests/Agon.Infrastructure.Tests/Attachments/AttachmentTextExtractorTests.cs
@@ -2,6 +2,9 @@ using Agon.Infrastructure.Attachments;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 
 namespace Agon.Infrastructure.Tests.Attachments;
 
@@ -57,10 +60,114 @@ public class AttachmentTextExtractorTests
         result.Should().BeNull();
     }
 
-    private static AttachmentTextExtractor CreateExtractor(AttachmentExtractionOptions options)
+    [Fact]
+    public async Task ExtractAsync_ImageVisionPrimaryModelFails_UsesFallbackModel()
+    {
+        var handler = new SequenceHandler([
+            // Primary model fails.
+            _ => new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("{\"error\":{\"message\":\"model not found\"}}", Encoding.UTF8, "application/json")
+            },
+            // Fallback model succeeds.
+            request =>
+            {
+                var body = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                using var doc = JsonDocument.Parse(body);
+                var model = doc.RootElement.GetProperty("model").GetString();
+                model.Should().Be("gpt-5.2");
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("""
+                    {
+                      "choices": [
+                        {
+                          "message": {
+                            "content": "Invoice total: $124.00"
+                          }
+                        }
+                      ]
+                    }
+                    """, Encoding.UTF8, "application/json")
+                };
+            }
+        ]);
+
+        var extractor = CreateExtractor(new AttachmentExtractionOptions
+        {
+            OpenAiVision = new OpenAiVisionExtractionOptions
+            {
+                Enabled = true,
+                ApiKey = "test-key",
+                Model = "gpt-4o-mini",
+                FallbackModel = "gpt-5.2"
+            }
+        }, handler);
+
+        var bytes = new byte[] { 1, 2, 3, 4, 5 };
+        var result = await extractor.ExtractAsync(bytes, "diagram.png", "image/png");
+
+        result.Should().Contain("Invoice total");
+        handler.CallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ImageWithoutVisionKey_FallsBackToDocumentIntelligence()
+    {
+        var handler = new SequenceHandler([
+            // Start analyze call.
+            _ => new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Headers =
+                {
+                    Location = new Uri("https://example.cognitiveservices.azure.com/ops/123")
+                },
+                Content = new StringContent("{}", Encoding.UTF8, "application/json")
+            },
+            // Poll call.
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                {
+                  "status": "succeeded",
+                  "analyzeResult": {
+                    "content": "Detected chart title: Q1 Revenue"
+                  }
+                }
+                """, Encoding.UTF8, "application/json")
+            }
+        ]);
+
+        var extractor = CreateExtractor(new AttachmentExtractionOptions
+        {
+            DocumentIntelligence = new DocumentIntelligenceExtractionOptions
+            {
+                Enabled = true,
+                Endpoint = "https://example.cognitiveservices.azure.com",
+                UseManagedIdentity = false,
+                ApiKey = "test-doc-key",
+                PollIntervalMs = 1,
+                MaxPollAttempts = 2
+            },
+            OpenAiVision = new OpenAiVisionExtractionOptions
+            {
+                Enabled = true,
+                ApiKey = ""
+            }
+        }, handler);
+
+        var bytes = new byte[] { 1, 2, 3, 4, 5 };
+        var result = await extractor.ExtractAsync(bytes, "diagram.png", "image/png");
+
+        result.Should().Contain("Q1 Revenue");
+        handler.CallCount.Should().Be(2);
+    }
+
+    private static AttachmentTextExtractor CreateExtractor(AttachmentExtractionOptions options, HttpMessageHandler? handler = null)
     {
         var httpClientFactory = Substitute.For<IHttpClientFactory>();
-        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(new DummyHandler()));
+        httpClientFactory.CreateClient(Arg.Any<string>()).Returns(new HttpClient(handler ?? new DummyHandler()));
         return new AttachmentTextExtractor(httpClientFactory, options, NullLogger<AttachmentTextExtractor>.Instance);
     }
 
@@ -72,6 +179,25 @@ public class AttachmentTextExtractorTests
             {
                 Content = new StringContent("{}")
             });
+        }
+    }
+
+    private sealed class SequenceHandler(IReadOnlyList<Func<HttpRequestMessage, HttpResponseMessage>> responses) : HttpMessageHandler
+    {
+        private int _index;
+
+        public int CallCount => _index;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_index >= responses.Count)
+            {
+                throw new InvalidOperationException($"Unexpected request #{_index + 1} ({request.Method} {request.RequestUri}).");
+            }
+
+            var response = responses[_index](request);
+            _index++;
+            return Task.FromResult(response);
         }
     }
 }

--- a/cli/.changeset/codex-style-attachment-refs.md
+++ b/cli/.changeset/codex-style-attachment-refs.md
@@ -1,0 +1,9 @@
+---
+"@agon_agents/cli": patch
+---
+
+Improve attachment UX and routing behavior:
+
+- show codex-style attachment references in shell output (`[Image #n]`, `[File #n]`) with distinct image/file coloring
+- improve attachment feedback readability by separating reference label and filename
+- keep simple image-description prompts in direct-answer mode instead of triggering full debate flow

--- a/cli/.changeset/fix-update-routing-image-vision.md
+++ b/cli/.changeset/fix-update-routing-image-vision.md
@@ -1,0 +1,9 @@
+---
+"@agon_agents/cli": patch
+---
+
+Improve shell UX and reliability in three areas:
+
+- Make `/update` restart guidance explicit so users know they must exit and relaunch to run the newly installed runtime.
+- Improve attachment feedback for image uploads when backend extraction returns no vision text.
+- Keep "attach anytime" flow behavior while clarifying extraction outcomes in shell output.

--- a/cli/.changeset/live-attachment-inline-color-and-routing.md
+++ b/cli/.changeset/live-attachment-inline-color-and-routing.md
@@ -1,0 +1,9 @@
+---
+"@agon_agents/cli": patch
+---
+
+Refine shell interaction and moderation behavior:
+
+- replace dragged/pasted file paths inline with codex-style attachment tokens in the prompt input (`[File #n]` / `[Image #n]`) and color only the attachment segment
+- update shell status guidance to focus on paste/drag attachment flow and include `/exit` / `Ctrl+C` exit hints
+- improve direct-answer routing heuristics and tests so simple requests avoid unnecessary full agent-cycle orchestration

--- a/cli/src/commands/self-update.ts
+++ b/cli/src/commands/self-update.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { checkForCliUpdate } from '../utils/update-check.js';
 import {
   describeSelfUpdateFailure,
+  getSelfUpdateRestartNotice,
   getSelfUpdateGuidance,
   runNpmGlobalInstall as npmGlobalInstall
 } from '../utils/self-update.js';
@@ -58,7 +59,7 @@ export default class SelfUpdate extends Command {
     try {
       await this.installLatest(packageName);
       installSpinner.succeed(`Updated to v${updateInfo.latestVersion}.`);
-      this.log(chalk.dim('Current process continues running this session. Restart later to use the updated runtime.'));
+      this.log(chalk.yellow(getSelfUpdateRestartNotice(updateInfo.latestVersion)));
     } catch (error) {
       installSpinner.fail('Update failed.');
       const failure = describeSelfUpdateFailure(error);

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -3,6 +3,7 @@ import ora from 'ora';
 import chalk from 'chalk';
 import { type Key } from 'node:readline';
 import { stdin as input, stdout as output } from 'node:process';
+import path from 'node:path';
 import { AgonAPIClient } from '../api/agon-client.js';
 import { ConfigManager } from '../state/config-manager.js';
 import { SessionManager } from '../state/session-manager.js';
@@ -14,7 +15,7 @@ import {
   type ShellEngineOutcome,
   type ShellSelfUpdateResult
 } from '../shell/engine.js';
-import { parseShellInput } from '../shell/parser.js';
+import { extractImplicitAttach, extractInlineAttach, parseShellInput } from '../shell/parser.js';
 import { routePlainInput } from '../shell/router.js';
 import {
   buildActivePrompt,
@@ -118,6 +119,7 @@ export default class Shell extends Command {
   private inRawInputMode = false;
   private apiClient?: AgonAPIClient;
   private sessionManager?: SessionManager;
+  private readonly livePreviewNextBySession = new Map<string, { image: number; file: number }>();
   private initializeKeypressEvents: () => void = () => {};
   private readonly promptHistory = new PromptHistory();
 
@@ -209,7 +211,8 @@ export default class Shell extends Command {
     try {
       while (true) {
         const promptFrame = renderPromptBanner((line) => this.log(line));
-        const rawInput = await this.promptForInput(promptFrame);
+        const activeSession = await controller.getActiveSession();
+        const rawInput = await this.promptForInput(promptFrame, activeSession?.id ?? null);
 
         if (rawInput === CTRL_C_EXIT_SENTINEL) {
           this.log(chalk.dim('Exiting shell.'));
@@ -343,15 +346,27 @@ export default class Shell extends Command {
         this.log(`Session ${outcome.sessionId} | status=${outcome.status} | phase=${outcome.phase}`);
         return;
       case 'attachment': {
+        this.syncLivePreviewCounter(outcome.sessionId, outcome.referenceLabel);
         const attachedLine = chalk.green('✓ Attached ')
-          + styleAttachmentToken(outcome.fileName)
+          + styleAttachmentToken(outcome.referenceLabel)
+          + chalk.green(' ')
+          + chalk.dim(`(${outcome.fileName})`)
           + chalk.green(` to session ${outcome.sessionId}`);
         this.log(attachedLine);
         this.log(chalk.dim(`Type: ${outcome.contentType} | Size: ${formatBytes(outcome.sizeBytes)}`));
         if (outcome.hasExtractedText) {
-          this.log(chalk.dim('Document text extracted and added to agent context.'));
+          this.log(chalk.dim('Attachment content extracted and added to agent context.'));
         } else {
-          this.log(chalk.dim('No text extraction available; file metadata/link still added to context.'));
+          if (outcome.contentType.toLowerCase().startsWith('image/')) {
+            this.log(
+              chalk.yellow(
+                'Image uploaded, but backend vision extraction returned no content. '
+                + 'Check OPENAI_KEY and ATTACHMENTPROCESSING__OPENAIVISION__ENABLED on backend.'
+              )
+            );
+          } else {
+            this.log(chalk.dim('No text extraction available; file metadata/link still added to context.'));
+          }
         }
         return;
       }
@@ -450,7 +465,8 @@ export default class Shell extends Command {
   }
 
   private async promptForInput(
-    frame: PromptFrameContext
+    frame: PromptFrameContext,
+    activeSessionId: string | null
   ): Promise<string> {
     if (!input.isTTY || typeof input.setRawMode !== 'function') {
       this.log(chalk.red('Interactive shell input requires a TTY.'));
@@ -473,11 +489,23 @@ export default class Shell extends Command {
       this.promptHistory.reset();
 
       const redraw = (): void => {
+        const preview = this.buildLiveAttachmentPreview(value, cursorIndex, activeSessionId);
+        const rendered = buildPromptInputLineWithCursor(frame, preview.displayValue, preview.displayCursorIndex);
+        const cursorAnchor = rendered.lastIndexOf('\r');
+        const beforeCursor = cursorAnchor >= 0 ? rendered.slice(0, cursorAnchor) : rendered;
+        const afterCursor = cursorAnchor >= 0 ? rendered.slice(cursorAnchor) : '';
+        const styledBefore = preview.highlightSegment
+          ? stylePromptAttachmentSegment(beforeCursor, preview.highlightSegment)
+          : beforeCursor;
+        const styledAfter = preview.highlightSegment
+          ? stylePromptAttachmentSegment(afterCursor, preview.highlightSegment)
+          : afterCursor;
+        const styled = `${styledBefore}${styledAfter}`;
         if (cursorLineIndex > 0) {
           output.write(`\u001b[${cursorLineIndex}A`);
         }
         output.write('\r');
-        output.write(buildPromptInputLineWithCursor(frame, value, cursorIndex));
+        output.write(styled);
         cursorLineIndex = getPromptCursorPosition(frame, value, cursorIndex).lineIndex;
       };
 
@@ -649,6 +677,94 @@ export default class Shell extends Command {
 
     input.pause();
     output.write('\u001b[0m\u001b[?25h\r\n');
+  }
+
+  private buildLiveAttachmentPreview(
+    inputValue: string,
+    cursorIndex: number,
+    activeSessionId: string | null
+  ): {
+    displayValue: string;
+    displayCursorIndex: number;
+    highlightSegment: string | null;
+  } {
+    const baseline = {
+      displayValue: inputValue,
+      displayCursorIndex: cursorIndex,
+      highlightSegment: null
+    };
+
+    const inlineAttach = extractInlineAttach(inputValue);
+    if (inlineAttach?.type === 'attach' || inlineAttach?.type === 'error') {
+      return baseline;
+    }
+
+    const implicitAttach = extractImplicitAttach(inputValue);
+    if (implicitAttach?.type !== 'attach') {
+      return baseline;
+    }
+
+    const rawPathRange = findRawAttachmentPathRange(inputValue, implicitAttach.path);
+    if (!rawPathRange) {
+      return baseline;
+    }
+
+    const isImage = isLikelyImagePath(implicitAttach.path);
+    const nextToken = this.peekLivePreviewToken(activeSessionId, isImage ? 'image' : 'file');
+    const token = isImage ? `[Image #${nextToken}]` : `[File #${nextToken}]`;
+    const fileName = path.basename(implicitAttach.path);
+    const replacement = `${token} ${fileName}`;
+    const displayValue = `${inputValue.slice(0, rawPathRange.start)}${replacement}${inputValue.slice(rawPathRange.end)}`;
+
+    const replacedLength = rawPathRange.end - rawPathRange.start;
+    const delta = replacement.length - replacedLength;
+    let displayCursorIndex = cursorIndex;
+    if (cursorIndex > rawPathRange.end) {
+      displayCursorIndex = cursorIndex + delta;
+    } else if (cursorIndex > rawPathRange.start) {
+      displayCursorIndex = rawPathRange.start + replacement.length;
+    }
+
+    return {
+      displayValue,
+      displayCursorIndex,
+      highlightSegment: replacement
+    };
+  }
+
+  private peekLivePreviewToken(
+    sessionId: string | null,
+    kind: 'image' | 'file'
+  ): number {
+    const key = sessionId ?? '__pending__';
+    const counters = this.livePreviewNextBySession.get(key) ?? { image: 1, file: 1 };
+    return kind === 'image' ? counters.image : counters.file;
+  }
+
+  private syncLivePreviewCounter(sessionId: string, referenceLabel: string): void {
+    const imageMatch = /^\[Image\s+#(\d+)\]$/i.exec(referenceLabel);
+    const fileMatch = /^\[File\s+#(\d+)\]$/i.exec(referenceLabel);
+
+    if (!imageMatch && !fileMatch) {
+      return;
+    }
+
+    const counters = this.livePreviewNextBySession.get(sessionId) ?? { image: 1, file: 1 };
+    if (imageMatch) {
+      const seen = Number.parseInt(imageMatch[1] ?? '0', 10);
+      if (Number.isFinite(seen)) {
+        counters.image = Math.max(counters.image, seen + 1);
+      }
+    }
+
+    if (fileMatch) {
+      const seen = Number.parseInt(fileMatch[1] ?? '0', 10);
+      if (Number.isFinite(seen)) {
+        counters.file = Math.max(counters.file, seen + 1);
+      }
+    }
+
+    this.livePreviewNextBySession.set(sessionId, counters);
   }
 
   private formatPhaseForDisplay(phase: string): string {
@@ -888,6 +1004,59 @@ function findNextWordBoundary(value: string, cursorIndex: number): number {
   }
 
   return index;
+}
+
+function isLikelyImagePath(filePath: string): boolean {
+  const extension = path.extname(filePath).toLowerCase();
+  return extension === '.png'
+    || extension === '.jpg'
+    || extension === '.jpeg'
+    || extension === '.gif'
+    || extension === '.webp'
+    || extension === '.bmp'
+    || extension === '.tif'
+    || extension === '.tiff'
+    || extension === '.heic'
+    || extension === '.heif';
+}
+
+function stylePromptAttachmentSegment(
+  rendered: string,
+  segment: string
+): string {
+  const escaped = escapeRegExp(segment);
+  const segmentPattern = new RegExp(escaped, 'g');
+  const accentStart = '\u001b[1m\u001b[38;2;132;255;142m';
+  const accentEnd = '\u001b[22m\u001b[97m';
+  return rendered.replace(segmentPattern, (match) => `${accentStart}${match}${accentEnd}`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function findRawAttachmentPathRange(
+  input: string,
+  normalizedPath: string
+): { start: number; end: number } | null {
+  const escapedSpaces = normalizedPath.replace(/ /g, '\\ ');
+  const candidates = [
+    `"${normalizedPath}"`,
+    `'${normalizedPath}'`,
+    `"${escapedSpaces}"`,
+    `'${escapedSpaces}'`,
+    escapedSpaces,
+    normalizedPath
+  ];
+
+  for (const candidate of candidates) {
+    const start = input.lastIndexOf(candidate);
+    if (start >= 0) {
+      return { start, end: start + candidate.length };
+    }
+  }
+
+  return null;
 }
 
 function getSpinnerText(parsed: ReturnType<typeof parseShellInput>): string | null {

--- a/cli/src/shell/engine.ts
+++ b/cli/src/shell/engine.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { SessionResponse } from '../api/types.js';
-import type { SelfUpdateFailureCategory } from '../utils/self-update.js';
+import { getSelfUpdateRestartNotice, type SelfUpdateFailureCategory } from '../utils/self-update.js';
 import { extractImplicitAttach, extractInlineAttach, parseShellInput } from './parser.js';
 import { styleAttachmentToken } from './renderer.js';
 import type { PlainInputRoute } from './router.js';
@@ -99,6 +99,7 @@ export type ShellEngineOutcome =
   | {
       kind: 'attachment';
       sessionId: string;
+      referenceLabel: string;
       fileName: string;
       contentType: string;
       sizeBytes: number;
@@ -111,6 +112,7 @@ export class ShellEngine {
   private readonly routePlainInputFn: (session: SessionResponse | null) => PlainInputRoute;
   private readonly selfUpdateFn: (options: { check: boolean }) => Promise<ShellSelfUpdateResult>;
   private readonly print: (line: string) => void;
+  private readonly attachmentRefCounters = new Map<string, { image: number; file: number }>();
 
   constructor(deps: ShellEngineDeps) {
     this.controller = deps.controller;
@@ -144,10 +146,12 @@ export class ShellEngine {
     let plainText = text;
     if (inlineAttach?.type === 'attach') {
       const result = await this.controller.attachDocument(inlineAttach.path);
+      const referenceLabel = this.nextAttachmentReferenceLabel(result.sessionId, result.attachment.contentType);
       if (!inlineAttach.remainingText) {
         return {
           kind: 'attachment',
           sessionId: result.sessionId,
+          referenceLabel,
           fileName: result.attachment.fileName,
           contentType: result.attachment.contentType,
           sizeBytes: result.attachment.sizeBytes,
@@ -156,14 +160,10 @@ export class ShellEngine {
       }
 
       this.print(
-        `Attached ${styleAttachmentToken(result.attachment.fileName)} to session ${result.sessionId}.`
+        `Attached ${styleAttachmentToken(referenceLabel)} (${styleAttachmentToken(result.attachment.fileName)}) to session ${result.sessionId}.`
         + ` Type: ${result.attachment.contentType} | Size: ${result.attachment.sizeBytes} B`
       );
-      if (result.attachment.hasExtractedText) {
-        this.print('Document text extracted and added to agent context.');
-      } else {
-        this.print('No text extraction available; file metadata/link still added to context.');
-      }
+      this.printAttachmentExtractionMessage(result.attachment.contentType, result.attachment.hasExtractedText);
 
       plainText = inlineAttach.remainingText;
     }
@@ -174,10 +174,12 @@ export class ShellEngine {
         const resolvedPath = await resolvePathIfExisting(implicitAttach.path);
         if (resolvedPath) {
           const result = await this.controller.attachDocument(resolvedPath);
+          const referenceLabel = this.nextAttachmentReferenceLabel(result.sessionId, result.attachment.contentType);
           if (!implicitAttach.remainingText) {
             return {
               kind: 'attachment',
               sessionId: result.sessionId,
+              referenceLabel,
               fileName: result.attachment.fileName,
               contentType: result.attachment.contentType,
               sizeBytes: result.attachment.sizeBytes,
@@ -186,14 +188,10 @@ export class ShellEngine {
           }
 
           this.print(
-            `Attached ${styleAttachmentToken(result.attachment.fileName)} to session ${result.sessionId}.`
+            `Attached ${styleAttachmentToken(referenceLabel)} (${styleAttachmentToken(result.attachment.fileName)}) to session ${result.sessionId}.`
             + ` Type: ${result.attachment.contentType} | Size: ${result.attachment.sizeBytes} B`
           );
-          if (result.attachment.hasExtractedText) {
-            this.print('Document text extracted and added to agent context.');
-          } else {
-            this.print('No text extraction available; file metadata/link still added to context.');
-          }
+          this.printAttachmentExtractionMessage(result.attachment.contentType, result.attachment.hasExtractedText);
 
           plainText = implicitAttach.remainingText;
         } else if (!implicitAttach.remainingText) {
@@ -324,7 +322,7 @@ export class ShellEngine {
             return { kind: 'noop' };
           case 'updated':
             this.print(`Updated CLI from v${result.currentVersion} to v${result.latestVersion}.`);
-            this.print('Current shell session stays active. Restart later to run the new runtime.');
+            this.print(getSelfUpdateRestartNotice(result.latestVersion));
             return { kind: 'noop' };
           case 'failed':
             this.print(`Self-update failed (${result.reason}): ${result.message}`);
@@ -396,9 +394,11 @@ export class ShellEngine {
       }
       case 'attach': {
         const result = await this.controller.attachDocument(parsed.path);
+        const referenceLabel = this.nextAttachmentReferenceLabel(result.sessionId, result.attachment.contentType);
         return {
           kind: 'attachment',
           sessionId: result.sessionId,
+          referenceLabel,
           fileName: result.attachment.fileName,
           contentType: result.attachment.contentType,
           sizeBytes: result.attachment.sizeBytes,
@@ -421,6 +421,37 @@ export class ShellEngine {
         };
       }
     }
+  }
+
+  private printAttachmentExtractionMessage(contentType: string, hasExtractedText: boolean): void {
+    if (hasExtractedText) {
+      this.print('Attachment content extracted and added to agent context.');
+      return;
+    }
+
+    if (contentType.toLowerCase().startsWith('image/')) {
+      this.print(
+        'Image uploaded, but backend vision extraction returned no content. '
+        + 'Verify backend OpenAI vision settings (OPENAI_KEY and ATTACHMENTPROCESSING__OPENAIVISION__ENABLED).'
+      );
+      return;
+    }
+
+    this.print('No text extraction available; file metadata/link still added to context.');
+  }
+
+  private nextAttachmentReferenceLabel(sessionId: string, contentType: string): string {
+    const counters = this.attachmentRefCounters.get(sessionId) ?? { image: 0, file: 0 };
+    const isImage = contentType.toLowerCase().startsWith('image/');
+    if (isImage) {
+      counters.image += 1;
+      this.attachmentRefCounters.set(sessionId, counters);
+      return `[Image #${counters.image}]`;
+    }
+
+    counters.file += 1;
+    this.attachmentRefCounters.set(sessionId, counters);
+    return `[File #${counters.file}]`;
   }
 }
 

--- a/cli/src/shell/parser.ts
+++ b/cli/src/shell/parser.ts
@@ -131,27 +131,36 @@ export function extractInlineAttach(input: string): InlineAttachExtraction | nul
 }
 
 export function extractImplicitAttach(input: string): InlineAttachExtraction | null {
-  const leadingWhitespaceTrimmed = input.trimStart();
-  if (!leadingWhitespaceTrimmed) {
+  if (!input.trim()) {
     return null;
   }
 
-  const startIndex = input.length - leadingWhitespaceTrimmed.length;
-  const parsedPath = parseAttachPathToken(input, startIndex);
-  if (!parsedPath) {
-    return null;
+  for (let index = 0; index < input.length; index += 1) {
+    if (!isPotentialPathStart(input, index)) {
+      continue;
+    }
+
+    const parsedPath = parseAttachPathToken(input, index);
+    if (!parsedPath) {
+      continue;
+    }
+
+    if (!isPathLikeCandidate(parsedPath.path)) {
+      continue;
+    }
+
+    const combinedRemaining = normalizeInlineMessageText(
+      `${input.slice(0, index)} ${input.slice(parsedPath.nextIndex)}`
+    );
+
+    return {
+      type: 'attach',
+      path: parsedPath.path,
+      remainingText: cleanConnectorArtifacts(combinedRemaining)
+    };
   }
 
-  if (!isPathLikeCandidate(parsedPath.path)) {
-    return null;
-  }
-
-  const remainingText = normalizeInlineMessageText(input.slice(parsedPath.nextIndex));
-  return {
-    type: 'attach',
-    path: parsedPath.path,
-    remainingText
-  };
+  return null;
 }
 
 function parseSet(args: string[]): ParsedShellInput {
@@ -460,16 +469,57 @@ function normalizeInlineMessageText(value: string): string {
     .trim();
 }
 
+function cleanConnectorArtifacts(value: string): string {
+  return value
+    .replace(/\s*(?:->|=>)\s*$/g, '')
+    .trim();
+}
+
 function decodeEscapedPath(rawPath: string): string {
   return rawPath.replace(/\\(.)/g, '$1');
 }
 
 function isPathLikeCandidate(value: string): boolean {
-  return value.startsWith('/')
-    || value.startsWith('./')
+  if (value.startsWith('/')) {
+    const remainder = value.slice(1);
+    return remainder.includes('/') || remainder.includes('.');
+  }
+
+  return value.startsWith('./')
     || value.startsWith('../')
     || value.startsWith('~/')
     || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isPotentialPathStart(input: string, index: number): boolean {
+  const char = input[index] ?? '';
+  const previous = index > 0 ? (input[index - 1] ?? '') : '';
+  const hasBoundary = index === 0 || /\s|[([{:>,'"`]/.test(previous);
+  if (!hasBoundary) {
+    return false;
+  }
+
+  if (char === '/' || char === '"' || char === '\'') {
+    return true;
+  }
+
+  if (char === '~') {
+    return (input[index + 1] ?? '') === '/';
+  }
+
+  if (char === '.') {
+    const next = input[index + 1] ?? '';
+    if (next === '/') {
+      return true;
+    }
+    return next === '.' && (input[index + 2] ?? '') === '/';
+  }
+
+  if (/[A-Za-z]/.test(char)) {
+    return /^[A-Za-z]:[\\/]/.test(input.slice(index));
+  }
+
+  return false;
 }
 
 function isLikelyPathToken(value: string): boolean {

--- a/cli/src/shell/renderer.ts
+++ b/cli/src/shell/renderer.ts
@@ -64,22 +64,27 @@ export function renderMessagePanel(
   print('');
 }
 
-/** Warm amber used as the canonical accent for all attachment token references. */
-const attachmentAccent = chalk.bold.rgb(248, 197, 71);
+/** Distinct accents for image vs file/path attachment references. */
+const imageAttachmentAccent = chalk.bold.yellowBright;
+const fileAttachmentAccent = chalk.bold.greenBright;
 
 /**
  * Regex that matches both Codex-style bracketed tokens and bare file paths:
  *   Group 1 – `[Image …]`, `[File …]`, `[Attachment …]`
  *   Group 2 – paths starting with `./`, `../`, or `/` (not `/ ` + space)
  */
-const attachmentRefPattern = /(\[(?:Image|File|Attachment)\s+[^\]\n]+\])|((?:\.\.?\/|\/(?!\s))[a-zA-Z0-9_\-./?&=#@:+%]+)/gi;
+const attachmentRefPattern = /(\[(?:Image|File)\s+#\d+\]\s+[^\s\]\n]+)|(\[(?:Image|File|Attachment)\s+[^\]\n]+\])|((?:\.\.?\/|\/(?!\s))[a-zA-Z0-9_\-./?&=#@:+%]+)/gi;
 
 /**
  * Style a single attachment token (file path or Codex-style image/file
  * reference) with the canonical attachment accent color.
  */
 export function styleAttachmentToken(token: string): string {
-  return attachmentAccent(token);
+  if (/^\[image\s+/i.test(token)) {
+    return imageAttachmentAccent(token);
+  }
+
+  return fileAttachmentAccent(token);
 }
 
 /**
@@ -149,10 +154,15 @@ export function buildPromptInputLine(frame: PromptFrameContext, value: string): 
   return buildPromptInputLineWithCursor(frame, value, value.length);
 }
 
+export interface PromptRenderOptions {
+  topOverlayText?: string;
+}
+
 export function buildPromptInputLineWithCursor(
   frame: PromptFrameContext,
   value: string,
-  cursorIndex: number
+  cursorIndex: number,
+  options?: PromptRenderOptions
 ): string {
   const editableLineCount = getEditableLineCount(frame);
   const visibleValue = getVisiblePromptValue(value, frame.maxInputChars);
@@ -165,6 +175,10 @@ export function buildPromptInputLineWithCursor(
     { length: frame.inputLineCount },
     () => `${frame.promptStart}${' '.repeat(frame.width)}${frame.reset}`
   );
+
+  if (options?.topOverlayText) {
+    lines[0] = buildOverlayLine(frame, options.topOverlayText);
+  }
 
   for (let index = 0; index < editableLineCount; index += 1) {
     const chunk = chunks[index] ?? '';
@@ -268,15 +282,15 @@ export function renderStatusLine(print: (line: string) => void): void {
   print(
     chalk.dim('Use ')
       + chalk.cyan('/new')
-      + chalk.dim(' for a new idea, ')
-      + chalk.cyan('/attach')
-      + chalk.dim(' or paste/drag a file path to add a document, ')
+      + chalk.dim(' for a new idea, paste/drag a file path to add a document, ')
       + chalk.cyan('/params')
       + chalk.dim(' to view params, ')
       + chalk.cyan('/set')
       + chalk.dim(' to change params, ')
       + chalk.cyan('/help')
-      + chalk.dim(' for commands.')
+      + chalk.dim(' for commands, ')
+      + chalk.cyan('/exit')
+      + chalk.dim(' or Ctrl+C to exit.')
   );
 }
 
@@ -395,6 +409,21 @@ function wrapPromptValue(value: string, maxWidth: number): WrappedPromptLines {
 interface VisibleWrappedWindow {
   lines: string[];
   cursorLineIndex: number;
+}
+
+function buildOverlayLine(frame: PromptFrameContext, content: string): string {
+  const visibleLength = stripAnsiCodes(content).length;
+  if (visibleLength > frame.width) {
+    const clipped = `${stripAnsiCodes(content).slice(0, frame.width - 1)}…`;
+    return `${frame.promptStart}${clipped.padEnd(frame.width, ' ')}${frame.reset}`;
+  }
+
+  const padding = ' '.repeat(Math.max(0, frame.width - visibleLength));
+  return `${frame.promptStart}${content}${padding}${frame.reset}`;
+}
+
+function stripAnsiCodes(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/g, '');
 }
 
 function getVisibleWrappedWindow(

--- a/cli/src/utils/self-update.ts
+++ b/cli/src/utils/self-update.ts
@@ -12,6 +12,10 @@ export interface SelfUpdateFailure {
   message: string;
 }
 
+export function getSelfUpdateRestartNotice(latestVersion: string): string {
+  return `Update installed, but this shell is still running the previous runtime. Exit now and restart Agon to use v${latestVersion}.`;
+}
+
 export function runNpmGlobalInstall(packageName: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn('npm', ['install', '-g', `${packageName}@latest`], {

--- a/cli/test/commands/self-update.test.ts
+++ b/cli/test/commands/self-update.test.ts
@@ -84,5 +84,8 @@ describe('self-update command', () => {
 
     await expect(command.run()).resolves.not.toThrow();
     expect(command.installedPackage).toBe('@agon_agents/cli');
+    expect(command.log).toHaveBeenCalledWith(
+      expect.stringContaining('Exit now and restart Agon to use v0.1.4.')
+    );
   });
 });

--- a/cli/test/shell/engine.test.ts
+++ b/cli/test/shell/engine.test.ts
@@ -254,6 +254,7 @@ describe('shell engine', () => {
     expect(outcome).toEqual({
       kind: 'attachment',
       sessionId: 'session-123',
+      referenceLabel: '[File #1]',
       fileName: 'spec.md',
       contentType: 'text/markdown',
       sizeBytes: 1024,
@@ -275,6 +276,7 @@ describe('shell engine', () => {
     expect(outcome).toEqual({
       kind: 'attachment',
       sessionId: 'session-123',
+      referenceLabel: '[File #1]',
       fileName: 'spec.md',
       contentType: 'text/markdown',
       sizeBytes: 1024,
@@ -293,6 +295,29 @@ describe('shell engine', () => {
 
     expect(controller.attachDocument).toHaveBeenCalledWith(filePath);
     expect(controller.submitFollowUp).toHaveBeenCalledWith('summarize key risks');
+    expect(outcome).toEqual({
+      kind: 'follow-up',
+      sessionId: 'session-123',
+      status: 'active',
+      phase: 'Clarification',
+      response: {
+        agentId: 'moderator',
+        message: 'Next question'
+      }
+    });
+  });
+
+  it('auto-attaches when drag-drop path appears after prompt text', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agon-shell-engine-'));
+    tempDirs.push(tempDir);
+    const filePath = path.join(tempDir, 'image 01.jpeg');
+    await fs.writeFile(filePath, 'fake', 'utf-8');
+    const escapedPath = filePath.replace(/ /g, '\\ ');
+
+    const outcome = await engine.handleInput(`Describe this image -> ${escapedPath}`);
+
+    expect(controller.attachDocument).toHaveBeenCalledWith(filePath);
+    expect(controller.submitFollowUp).toHaveBeenCalledWith('Describe this image');
     expect(outcome).toEqual({
       kind: 'follow-up',
       sessionId: 'session-123',
@@ -328,5 +353,64 @@ describe('shell engine', () => {
     expect(selfUpdate).toHaveBeenCalledWith({ check: true });
     expect(outcome).toEqual({ kind: 'noop' });
     expect(print).toHaveBeenCalledWith('Update available: v0.1.10 -> v0.1.11');
+  });
+
+  it('prints explicit restart guidance after /update installs a new version', async () => {
+    selfUpdate.mockResolvedValueOnce({
+      status: 'updated',
+      currentVersion: '0.5.1',
+      latestVersion: '0.6.0'
+    });
+
+    const outcome = await engine.handleInput('/update');
+
+    expect(outcome).toEqual({ kind: 'noop' });
+    expect(print).toHaveBeenCalledWith('Updated CLI from v0.5.1 to v0.6.0.');
+    expect(print).toHaveBeenCalledWith(
+      'Update installed, but this shell is still running the previous runtime. Exit now and restart Agon to use v0.6.0.'
+    );
+  });
+
+  it('assigns codex-style attachment labels per session for images', async () => {
+    controller.attachDocument.mockResolvedValueOnce({
+      sessionId: 'session-123',
+      attachment: {
+        fileName: 'image-one.jpeg',
+        contentType: 'image/jpeg',
+        sizeBytes: 2048,
+        hasExtractedText: true
+      }
+    });
+    controller.attachDocument.mockResolvedValueOnce({
+      sessionId: 'session-123',
+      attachment: {
+        fileName: 'image-two.jpeg',
+        contentType: 'image/jpeg',
+        sizeBytes: 4096,
+        hasExtractedText: true
+      }
+    });
+
+    const first = await engine.handleInput('/attach /tmp/image-one.jpeg');
+    const second = await engine.handleInput('/attach /tmp/image-two.jpeg');
+
+    expect(first).toEqual({
+      kind: 'attachment',
+      sessionId: 'session-123',
+      referenceLabel: '[Image #1]',
+      fileName: 'image-one.jpeg',
+      contentType: 'image/jpeg',
+      sizeBytes: 2048,
+      hasExtractedText: true
+    });
+    expect(second).toEqual({
+      kind: 'attachment',
+      sessionId: 'session-123',
+      referenceLabel: '[Image #2]',
+      fileName: 'image-two.jpeg',
+      contentType: 'image/jpeg',
+      sizeBytes: 4096,
+      hasExtractedText: true
+    });
   });
 });

--- a/cli/test/shell/parser.test.ts
+++ b/cli/test/shell/parser.test.ts
@@ -314,7 +314,27 @@ describe('shell parser', () => {
     });
   });
 
+  it('extracts implicit attach when drag-drop path appears after prompt text', () => {
+    expect(extractImplicitAttach('Describe this image -> /Users/simonholmes/Pictures/Photos\\ Library.photoslibrary/resources/derivatives/B/example.jpeg')).toEqual({
+      type: 'attach',
+      path: '/Users/simonholmes/Pictures/Photos Library.photoslibrary/resources/derivatives/B/example.jpeg',
+      remainingText: 'Describe this image'
+    });
+  });
+
+  it('extracts implicit attach when quoted path appears after prompt text', () => {
+    expect(extractImplicitAttach('Summarize this file "/Users/simonholmes/Documents/my notes.pdf"')).toEqual({
+      type: 'attach',
+      path: '/Users/simonholmes/Documents/my notes.pdf',
+      remainingText: 'Summarize this file'
+    });
+  });
+
   it('does not treat non-path plain text as implicit attach', () => {
     expect(extractImplicitAttach('Please summarize this')).toBeNull();
+  });
+
+  it('does not treat slash endpoint tokens as implicit file attach', () => {
+    expect(extractImplicitAttach('Check /health endpoint status')).toBeNull();
   });
 });

--- a/cli/test/shell/renderer.test.ts
+++ b/cli/test/shell/renderer.test.ts
@@ -162,6 +162,21 @@ describe('shell renderer', () => {
     expect(cursorSegment).toContain('  > hello');
     expect(cursorSegment).not.toContain('  > hello world');
   });
+
+  it('renders top overlay text for live attachment preview', () => {
+    const frame = renderPromptBanner(() => {});
+    const rendered = buildPromptInputLineWithCursor(
+      frame,
+      'Describe this image -> /tmp/cat.jpg',
+      32,
+      { topOverlayText: '  pending [Image #1] cat.jpg' }
+    );
+    const plain = rendered.replace(/\u001b\[[0-9;]*m/g, '');
+    const rows = plain.split('\n');
+
+    expect(rows[0]).toContain('pending [Image #1] cat.jpg');
+    expect(rows[1]).toContain('  > ');
+  });
 });
 
 describe('formatElapsedTimer', () => {
@@ -247,6 +262,22 @@ describe('styleAttachmentToken', () => {
       expect(styled).not.toBe(plain);
     }
     expect(stripAnsi(styled)).toBe(plain);
+  });
+
+  it('uses distinct styles for [Image ...] vs file/path tokens when ANSI is enabled', () => {
+    const imageToken = '[Image #1]';
+    const fileToken = './docs/spec.md';
+    const styledImage = styleAttachmentToken(imageToken);
+    const styledFile = styleAttachmentToken(fileToken);
+
+    expect(stripAnsi(styledImage)).toBe(imageToken);
+    expect(stripAnsi(styledFile)).toBe(fileToken);
+
+    const imageHasAnsi = /\u001b\[[0-9;]*m/.test(styledImage);
+    const fileHasAnsi = /\u001b\[[0-9;]*m/.test(styledFile);
+    if (imageHasAnsi && fileHasAnsi) {
+      expect(styledImage).not.toBe(styledFile);
+    }
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "cli": {
       "name": "@agon_agents/cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3.0.0",


### PR DESCRIPTION
## Summary
This PR fixes the regressions you flagged around update guidance, routing, and attachment UX.

## What changed

### CLI: explicit post-update relaunch guidance
- unified restart notice text via `getSelfUpdateRestartNotice(...)`
- updated both in-shell `/update` path and `self-update` command output
- added regression tests for explicit restart wording

### CLI: attachment UX (drag/paste-first flow)
- implicit attach parser now supports inline path usage robustly (including quoted paths)
- prompt input now replaces raw local paths inline with codex-style tokens:
  - `[File #n] <name>`
  - `[Image #n] <name>`
- inline attachment segment is colorized while normal query text remains unchanged
- status hint line now reflects current UX:
  - removed explicit `/attach` dependency wording
  - added `/exit` and `Ctrl+C` exit hint

### Backend: moderator routing hardening
- introduced shared `ModeratorRoutingClassifier` (single source of truth)
- deterministic direct-answer short-circuit for simple direct questions
- intent router now skipped when deterministic direct-answer applies
- `Orchestrator` now uses same classifier when interpreting `READY`
- added orchestration regression tests for direct-answer suppression of unnecessary full debate

## Validation
- `npm --prefix cli run build`
- `npm --prefix cli test`
- `dotnet test backend/Agon.sln --verbosity minimal`

## Notes
- This PR focuses on correctness and UX for update messaging, routing, and attachments.
- Local developer-only file `cli/.agonrc` was intentionally not committed.
