### PR TITLE
fix(cli+backend): enforce direct-answer for simple prompts and harden image analysis

### DIFF
--- a/backend/src/Agon.Api/Configuration/AttachmentProcessingConfiguration.cs
+++ b/backend/src/Agon.Api/Configuration/AttachmentProcessingConfiguration.cs
@@ -31,5 +31,5 @@ public sealed class OpenAiVisionProcessingConfiguration
     public string FallbackModel { get; set; } = string.Empty;
     public int MaxTokens { get; set; } = 1200;
     public string Detail { get; set; } = "auto";
-    public int MaxImageBytes { get; set; } = 6291456;
+    public int MaxImageBytes { get; set; } = 20971520;
 }

--- a/backend/src/Agon.Api/Controllers/SessionsController.cs
+++ b/backend/src/Agon.Api/Controllers/SessionsController.cs
@@ -758,8 +758,13 @@ public class SessionsController : ControllerBase
             ".pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             ".png" => "image/png",
             ".jpg" or ".jpeg" => "image/jpeg",
+            ".jfif" => "image/jpeg",
             ".gif" => "image/gif",
+            ".bmp" => "image/bmp",
+            ".tif" or ".tiff" => "image/tiff",
             ".webp" => "image/webp",
+            ".heic" => "image/heic",
+            ".heif" => "image/heif",
             _ => "application/octet-stream"
         };
     }

--- a/backend/src/Agon.Api/appsettings.json
+++ b/backend/src/Agon.Api/appsettings.json
@@ -54,7 +54,7 @@
       "FallbackModel": "",
       "MaxTokens": 1200,
       "Detail": "auto",
-      "MaxImageBytes": 6291456
+      "MaxImageBytes": 20971520
     }
   },
 

--- a/backend/src/Agon.Application/Orchestration/AgentRunner.cs
+++ b/backend/src/Agon.Application/Orchestration/AgentRunner.cs
@@ -132,6 +132,10 @@ public sealed class AgentRunner : IAgentRunner
             state,
             response,
             cancellationToken);
+        response = CoerceModeratorDirectAnswerIfRequired(
+            response,
+            shouldForceDirectAnswer,
+            state);
 
         if (response.HasPatch && GetModeratorPatchValidationError(response.Patch!, state) is not null)
         {
@@ -358,6 +362,65 @@ public sealed class AgentRunner : IAgentRunner
         var match = ModeratorStatusRegex.Match(message);
         return match.Success ? match.Groups[1].Value.Trim().ToUpperInvariant() : null;
     }
+
+    private static AgentResponse CoerceModeratorDirectAnswerIfRequired(
+        AgentResponse response,
+        bool shouldForceDirectAnswer,
+        SessionState state)
+    {
+        if (!shouldForceDirectAnswer || response.TimedOut)
+        {
+            return response;
+        }
+
+        var status = ParseModeratorStatus(response.Message);
+        var body = StripLeadingStatusLine(response.Message);
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            body = "I can help with that.";
+        }
+
+        var message = status == "DIRECT_ANSWER"
+            ? response.Message
+            : $"STATUS: DIRECT_ANSWER\n{body}";
+
+        return response with
+        {
+            Message = message,
+            Patch = BuildEmptyModeratorPatch(state, "Direct-answer path: no Truth Map mutation.")
+        };
+    }
+
+    private static string StripLeadingStatusLine(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return string.Empty;
+        }
+
+        var normalized = message.Replace("\r\n", "\n").Replace('\r', '\n');
+        var lines = normalized.Split('\n');
+        if (lines.Length == 0)
+        {
+            return normalized.Trim();
+        }
+
+        if (!ModeratorStatusRegex.IsMatch(lines[0]))
+        {
+            return normalized.Trim();
+        }
+
+        return string.Join('\n', lines.Skip(1)).Trim();
+    }
+
+    private static TruthMapPatch BuildEmptyModeratorPatch(SessionState state, string reason) =>
+        new(
+            [],
+            new PatchMeta(
+                Domain.Agents.AgentId.Moderator,
+                state.ClarificationRoundCount,
+                reason,
+                state.SessionId));
 
     private static ModeratorRoute ParseModeratorRoute(string? message)
     {

--- a/backend/src/Agon.Application/Orchestration/ModeratorRoutingClassifier.cs
+++ b/backend/src/Agon.Application/Orchestration/ModeratorRoutingClassifier.cs
@@ -61,7 +61,7 @@ internal static class ModeratorRoutingClassifier
             return false;
         }
 
-        return LooksLikeSimpleDirectQuery(latestInput, state.Attachments.Count > 0);
+        return LooksLikeSimpleDirectQuery(latestInput);
     }
 
     private static string GetLatestUserInput(SessionState state)
@@ -74,7 +74,7 @@ internal static class ModeratorRoutingClassifier
         return state.Idea ?? string.Empty;
     }
 
-    private static bool LooksLikeSimpleDirectQuery(string input, bool hasAttachments)
+    private static bool LooksLikeSimpleDirectQuery(string input)
     {
         var trimmed = input.Trim();
         if (trimmed.Length is < 4 or > 280)
@@ -82,7 +82,12 @@ internal static class ModeratorRoutingClassifier
             return false;
         }
 
-        var attachmentImperative = hasAttachments && AttachmentDirectActionRegex.IsMatch(trimmed);
+        var attachmentImperative = AttachmentDirectActionRegex.IsMatch(trimmed);
+        if (attachmentImperative && !FullDebateIntentRegex.IsMatch(trimmed))
+        {
+            return true;
+        }
+
         var utilityImperative = LooksLikeUtilityImperative(trimmed);
         if (!LooksLikeQuestion(trimmed) && !attachmentImperative && !utilityImperative)
         {

--- a/backend/src/Agon.Infrastructure/Attachments/AttachmentExtractionOptions.cs
+++ b/backend/src/Agon.Infrastructure/Attachments/AttachmentExtractionOptions.cs
@@ -30,5 +30,5 @@ public sealed class OpenAiVisionExtractionOptions
     public string FallbackModel { get; set; } = string.Empty;
     public int MaxTokens { get; set; } = 1200;
     public string Detail { get; set; } = "auto";
-    public int MaxImageBytes { get; set; } = 6 * 1024 * 1024;
+    public int MaxImageBytes { get; set; } = 20 * 1024 * 1024;
 }

--- a/backend/src/Agon.Infrastructure/Attachments/AttachmentTextExtractor.cs
+++ b/backend/src/Agon.Infrastructure/Attachments/AttachmentTextExtractor.cs
@@ -56,17 +56,21 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
 
     private static readonly HashSet<string> ImageExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
-        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tif", ".tiff"
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tif", ".tiff", ".heic", ".heif", ".jfif"
     };
 
     private static readonly HashSet<string> ImageContentTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "image/png",
         "image/jpeg",
+        "image/jpg",
+        "image/pjpeg",
         "image/gif",
         "image/bmp",
         "image/webp",
-        "image/tiff"
+        "image/tiff",
+        "image/heic",
+        "image/heif"
     };
 
     private readonly IHttpClientFactory _httpClientFactory;
@@ -499,6 +503,11 @@ public sealed class AttachmentTextExtractor : IAttachmentTextExtractor
                     .OfType<string>();
 
                 return string.Join("\n", parts);
+            }
+
+            if (content.ValueKind == JsonValueKind.Object)
+            {
+                return ExtractContentText(content);
             }
 
             return ParseResponsesApiContent(document.RootElement);

--- a/backend/tests/Agon.Application.Tests/Orchestration/AgentRunnerTests.cs
+++ b/backend/tests/Agon.Application.Tests/Orchestration/AgentRunnerTests.cs
@@ -858,6 +858,84 @@ public class AgentRunnerTests
         response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
     }
 
+    [Fact]
+    public async Task RunModeratorAsync_AttachmentImperativePromptWithoutAttachment_ShouldStillUseDeterministicDirectAnswerPath()
+    {
+        // Arrange
+        var repo = StubRepo();
+        var capturedContexts = new List<AgentContext>();
+
+        var moderator = Substitute.For<ICouncilAgent>();
+        moderator.AgentId.Returns(AgentId.Moderator);
+        moderator.ModelProvider.Returns("fake/model");
+        moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new AgentResponse(
+                AgentId.Moderator,
+                "STATUS: DIRECT_ANSWER\nPlease upload an image and I will describe it.",
+                null,
+                55,
+                false,
+                null)));
+
+        var runner = BuildRunner([moderator], repo: repo);
+        var state = BuildSessionState(idea: "Describe this image");
+        state.Phase = SessionPhase.Clarification;
+
+        // Act
+        var response = await runner.RunModeratorAsync(state, CancellationToken.None);
+
+        // Assert
+        await moderator.Received(1).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(1);
+        capturedContexts[0].MicroDirective.Should().Contain("STATUS: DIRECT_ANSWER");
+        response.Message.Should().Contain("STATUS: DIRECT_ANSWER");
+    }
+
+    [Fact]
+    public async Task RunModeratorAsync_DirectAnswerRoute_ShouldCoerceNonDirectModeratorStatuses()
+    {
+        // Arrange
+        var repo = StubRepo();
+        var capturedContexts = new List<AgentContext>();
+
+        var moderator = Substitute.For<ICouncilAgent>();
+        moderator.AgentId.Returns(AgentId.Moderator);
+        moderator.ModelProvider.Returns("fake/model");
+        moderator.RunAsync(Arg.Do<AgentContext>(ctx => capturedContexts.Add(ctx)), Arg.Any<CancellationToken>())
+            .Returns(
+                Task.FromResult(new AgentResponse(
+                    AgentId.Moderator,
+                    "STATUS: NEEDS_INFO\nCan you clarify what you mean?",
+                    null,
+                    50,
+                    false,
+                    null)),
+                Task.FromResult(new AgentResponse(
+                    AgentId.Moderator,
+                    "STATUS: READY\nDNS maps hostnames to IP addresses.",
+                    null,
+                    65,
+                    false,
+                    null)));
+
+        var runner = BuildRunner([moderator], repo: repo);
+        var state = BuildSessionState(idea: "What is DNS?");
+        state.Phase = SessionPhase.Clarification;
+        state.ClarificationRoundCount = 1;
+
+        // Act
+        var response = await runner.RunModeratorAsync(state, CancellationToken.None);
+
+        // Assert
+        await moderator.Received(2).RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>());
+        capturedContexts.Should().HaveCount(2);
+        response.Message.Should().StartWith("STATUS: DIRECT_ANSWER");
+        response.Patch.Should().NotBeNull();
+        response.Patch!.Ops.Should().BeEmpty();
+        response.Patch.Meta.Agent.Should().Be(AgentId.Moderator);
+        response.Patch.Meta.Round.Should().Be(state.ClarificationRoundCount);
+    }
+
     // ── Post-delivery follow-up tests ────────────────────────────────────────
 
     [Fact]

--- a/backend/tests/Agon.Application.Tests/Orchestration/OrchestratorTests.cs
+++ b/backend/tests/Agon.Application.Tests/Orchestration/OrchestratorTests.cs
@@ -970,6 +970,45 @@ public class OrchestratorTests
     }
 
     [Fact]
+    public async Task RunModeratorAsync_WithReadyAndAttachmentImperativeWithoutAttachment_ShouldSuppressDebateChain()
+    {
+        var runner = Substitute.For<IAgentRunner>();
+        var moderatorResponse = new AgentResponse(
+            AgentId.Moderator,
+            "STATUS: READY\nPlease upload the image and I can describe it.",
+            null,
+            80,
+            false,
+            null);
+
+        runner.RunModeratorAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(moderatorResponse));
+
+        var sessionService = StubSessionService();
+        var orchestrator = BuildOrchestrator(
+            runner: runner,
+            sessionService: sessionService);
+
+        var state = BuildState(SessionPhase.Clarification);
+        state.ClarificationRoundCount = 1;
+        state.UserMessages.Add(new UserMessage(
+            "Describe this image",
+            DateTimeOffset.UtcNow,
+            1));
+
+        await orchestrator.RunModeratorAsync(state, CancellationToken.None);
+
+        state.ClarificationRoundCount.Should().Be(1);
+        await sessionService.DidNotReceive().AdvancePhaseAsync(
+            state,
+            SessionPhase.AnalysisRound,
+            Arg.Any<CancellationToken>());
+        await sessionService.DidNotReceive().RecordRoundSnapshotAsync(
+            state,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RunModeratorAsync_ReadyOnFirstRoundWithoutUserMessages_ShouldNotAdvance()
     {
         var runner = Substitute.For<IAgentRunner>();

--- a/backend/tests/Agon.Infrastructure.Tests/Attachments/AttachmentTextExtractorTests.cs
+++ b/backend/tests/Agon.Infrastructure.Tests/Attachments/AttachmentTextExtractorTests.cs
@@ -164,6 +164,46 @@ public class AttachmentTextExtractorTests
         handler.CallCount.Should().Be(2);
     }
 
+    [Fact]
+    public async Task ExtractAsync_ImageVisionWithObjectContent_ParsesText()
+    {
+        var handler = new SequenceHandler([
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": {
+                          "type": "output_text",
+                          "text": "Screenshot shows a blue dashboard with status cards."
+                        }
+                      }
+                    }
+                  ]
+                }
+                """, Encoding.UTF8, "application/json")
+            }
+        ]);
+
+        var extractor = CreateExtractor(new AttachmentExtractionOptions
+        {
+            OpenAiVision = new OpenAiVisionExtractionOptions
+            {
+                Enabled = true,
+                ApiKey = "test-key",
+                Model = "gpt-4o-mini"
+            }
+        }, handler);
+
+        var bytes = new byte[] { 1, 2, 3, 4, 5 };
+        var result = await extractor.ExtractAsync(bytes, "snapshot.jpeg", "image/jpeg");
+
+        result.Should().Contain("blue dashboard");
+        handler.CallCount.Should().Be(1);
+    }
+
     private static AttachmentTextExtractor CreateExtractor(AttachmentExtractionOptions options, HttpMessageHandler? handler = null)
     {
         var httpClientFactory = Substitute.For<IHttpClientFactory>();

--- a/cli/.changeset/fix-direct-answer-and-image-vision.md
+++ b/cli/.changeset/fix-direct-answer-and-image-vision.md
@@ -1,0 +1,10 @@
+---
+"@agon_agents/cli": patch
+---
+
+Improve reliability for simple-query routing and image attachment handling:
+
+- prevent accidental message submission when implicit drag/paste attachment path cannot be resolved
+- expand image MIME/extension recognition for upload and extraction paths
+- improve extraction compatibility for additional OpenAI vision response shapes
+- keep simple requests (including image-description asks) on deterministic direct-answer path to avoid unnecessary full debate cycles

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -505,8 +505,14 @@ function guessContentType(fileName: string): string {
     '.png': 'image/png',
     '.jpg': 'image/jpeg',
     '.jpeg': 'image/jpeg',
+    '.jfif': 'image/jpeg',
     '.gif': 'image/gif',
-    '.webp': 'image/webp'
+    '.bmp': 'image/bmp',
+    '.tif': 'image/tiff',
+    '.tiff': 'image/tiff',
+    '.webp': 'image/webp',
+    '.heic': 'image/heic',
+    '.heif': 'image/heif'
   };
 
   return map[extension] ?? 'application/octet-stream';

--- a/cli/src/shell/engine.ts
+++ b/cli/src/shell/engine.ts
@@ -170,10 +170,10 @@ export class ShellEngine {
 
     if (!inlineAttach) {
       const implicitAttach = extractImplicitAttach(text);
-      if (implicitAttach?.type === 'attach') {
-        const resolvedPath = await resolvePathIfExisting(implicitAttach.path);
-        if (resolvedPath) {
-          const result = await this.controller.attachDocument(resolvedPath);
+        if (implicitAttach?.type === 'attach') {
+          const resolvedPath = await resolvePathIfExisting(implicitAttach.path);
+          if (resolvedPath) {
+            const result = await this.controller.attachDocument(resolvedPath);
           const referenceLabel = this.nextAttachmentReferenceLabel(result.sessionId, result.attachment.contentType);
           if (!implicitAttach.remainingText) {
             return {
@@ -194,9 +194,9 @@ export class ShellEngine {
           this.printAttachmentExtractionMessage(result.attachment.contentType, result.attachment.hasExtractedText);
 
           plainText = implicitAttach.remainingText;
-        } else if (!implicitAttach.remainingText) {
+        } else {
           this.print(`File not found: ${implicitAttach.path}`);
-          this.print('Use /attach <file-path> for explicit attach, or provide a valid local file path.');
+          this.print('Attachment was not sent. Provide a valid local file path, then retry.');
           return { kind: 'noop' };
         }
       }

--- a/cli/test/shell/engine.test.ts
+++ b/cli/test/shell/engine.test.ts
@@ -340,6 +340,17 @@ describe('shell engine', () => {
     expect(print).toHaveBeenCalledWith('File not found: /tmp/agon-shell-engine-missing-file.pdf');
   });
 
+  it('does not submit plain text when implicit attach path is missing but prompt text exists', async () => {
+    const outcome = await engine.handleInput('Describe this image -> /tmp/agon-shell-engine-missing-file.jpeg');
+
+    expect(outcome).toEqual({ kind: 'noop' });
+    expect(controller.attachDocument).not.toHaveBeenCalled();
+    expect(controller.startIdea).not.toHaveBeenCalled();
+    expect(controller.submitFollowUp).not.toHaveBeenCalled();
+    expect(print).toHaveBeenCalledWith('File not found: /tmp/agon-shell-engine-missing-file.jpeg');
+    expect(print).toHaveBeenCalledWith('Attachment was not sent. Provide a valid local file path, then retry.');
+  });
+
   it('runs /update --check through updater callback', async () => {
     selfUpdate.mockResolvedValueOnce({
       status: 'update-available',


### PR DESCRIPTION
## Summary
This PR addresses the two regressions reported in production:

1. Simple user prompts were still triggering the full agent cycle.
2. Image requests could degrade into "cannot analyze image" behavior.

## Fixes included

### 1) Deterministic simple-query routing (no unnecessary agent cycle)
- Broadened deterministic direct-answer classification for attachment-imperative requests (e.g. `Describe this image`) even when attachment context is delayed/missing.
- Added a hard safety net in `AgentRunner`: when direct-answer routing is selected, moderator output is coerced to `STATUS: DIRECT_ANSWER` and Truth Map mutation is neutralized with an empty moderator patch.
- This prevents debate-chain escalation when the moderator returns `READY`/`NEEDS_INFO` for a clearly simple request.

### 2) Image analysis reliability hardening
- Expanded image type support across upload/extraction paths (`.heic`, `.heif`, `.jfif`, `.bmp`, `.tif/.tiff`, `image/jpg`, `image/heic`, `image/heif`, etc.).
- Increased OpenAI vision default max image size from 6 MB to 20 MB.
- Improved OpenAI response parsing for object-shaped `message.content` payloads.
- Prevented accidental local-path leak into LLM prompts when implicit drag/paste attach path cannot be resolved; request is now blocked with an actionable message instead of being sent as plain text.

## Tests added/updated
- `AgentRunnerTests`
  - attachment-imperative prompt without attachment still routes direct-answer
  - forced direct-answer path coerces non-direct moderator statuses
- `OrchestratorTests`
  - READY + attachment-imperative without attachment suppresses debate-chain transition
- `AttachmentTextExtractorTests`
  - parses object-shaped OpenAI vision content
- `cli/test/shell/engine.test.ts`
  - blocks submit when implicit attachment path is missing even if prompt text exists

## Validation run
- `npm --prefix cli run build`
- `npm --prefix cli test`
- `DOTNET_CLI_HOME=/tmp dotnet test backend/Agon.sln --verbosity minimal`
