### PR TITLE
feat(cli): add first-class Azure CLI login workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ No bearer token is configured for backend https://your-agon-host.
 
 First-time setup:
   agon login              Save your bearer token
+  agon login --azure-cli --scope api://<app-id>/.default
   agon login --status     Check current auth status
 ```
 
@@ -383,7 +384,16 @@ agon login
 agon login --token "<your-bearer-token>"
 ```
 
-If you use Microsoft Entra for Agon API auth, you can mint a token via Azure CLI:
+Recommended for Microsoft Entra-backed APIs:
+
+```bash
+agon login --azure-cli --scope "api://<agon-api-app-id>/.default"
+```
+
+Notes:
+- You can also set `AGON_AUTH_SCOPE` to pre-fill the scope for interactive login.
+- `--tenant <tenant-id>` is supported if you need to pin the tenant.
+- Manual Azure flow remains valid if preferred:
 
 ```bash
 az login
@@ -400,6 +410,9 @@ Additional `agon login` flags:
 | Flag | Description |
 |---|---|
 | `--token <token>` | Supply token directly (non-interactive) |
+| `--azure-cli` | Obtain token from Azure CLI and store it |
+| `--scope <scope>` | Scope/App ID URI for `--azure-cli` mode |
+| `--tenant <tenant-id>` | Optional tenant for `--azure-cli` mode |
 | `--clear` | Remove the stored token |
 | `--status` | Show whether a token is configured and whether the backend requires one |
 

--- a/cli/.changeset/azure-cli-login-workflow.md
+++ b/cli/.changeset/azure-cli-login-workflow.md
@@ -1,0 +1,12 @@
+---
+"@agon_agents/cli": minor
+---
+
+Add first-class Azure CLI login workflow for bearer token acquisition.
+
+Highlights:
+- Add `agon login --azure-cli --scope <scope> [--tenant <tenant-id>]`.
+- Add interactive method selection in `agon login` (Azure CLI recommended vs manual token paste).
+- Normalize Entra scope inputs (`<app-id>` / `api://<app-id>` / `api://<app-id>/.default`).
+- Add clearer auth guidance in `shell` and `start` first-time setup output.
+- Document `AGON_AUTH_SCOPE` as a prefill convenience for interactive login.

--- a/cli/src/auth/azure-cli-token-provider.ts
+++ b/cli/src/auth/azure-cli-token-provider.ts
@@ -1,0 +1,158 @@
+import { execFile } from 'node:child_process';
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export interface AzureCliTokenOptions {
+  scope: string;
+  tenant?: string;
+  interactiveLogin?: boolean;
+}
+
+export class AzureCliTokenProviderError extends Error {
+  readonly code: 'AZURE_CLI_NOT_FOUND' | 'AZURE_CLI_LOGIN_REQUIRED' | 'AZURE_CLI_TOKEN_FAILED' | 'INVALID_SCOPE';
+
+  constructor(
+    code: AzureCliTokenProviderError['code'],
+    message: string,
+    readonly causeDetail?: string,
+  ) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export function normalizeAzureScope(rawScope: string): string {
+  const scope = rawScope.trim();
+  if (!scope) {
+    throw new AzureCliTokenProviderError(
+      'INVALID_SCOPE',
+      'Azure scope must not be empty.',
+      'Provide a scope like api://<api-app-id>/.default',
+    );
+  }
+
+  if (scope.endsWith('/.default')) {
+    return scope;
+  }
+
+  if (uuidPattern.test(scope)) {
+    return `api://${scope}/.default`;
+  }
+
+  if (scope.startsWith('api://') || scope.includes('://')) {
+    return `${scope}/.default`;
+  }
+
+  return `api://${scope}/.default`;
+}
+
+async function runAz(args: string[]): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    execFile(
+      'az',
+      args,
+      { maxBuffer: 1024 * 1024 * 4 },
+      (error, stdout, stderr) => {
+        if (error) {
+          const err = error as NodeJS.ErrnoException;
+          if (err.code === 'ENOENT') {
+            reject(new AzureCliTokenProviderError(
+              'AZURE_CLI_NOT_FOUND',
+              'Azure CLI (az) was not found on PATH.',
+              'Install Azure CLI: https://aka.ms/azure-cli',
+            ));
+            return;
+          }
+
+          reject(new AzureCliTokenProviderError(
+            'AZURE_CLI_TOKEN_FAILED',
+            'Azure CLI command failed.',
+            (stderr || '').toString().trim() || err.message,
+          ));
+          return;
+        }
+
+        resolve((stdout || '').toString().trim());
+      },
+    );
+  });
+}
+
+async function ensureAzureAccount(interactiveLogin: boolean): Promise<void> {
+  try {
+    await runAz(['account', 'show', '--output', 'none']);
+    return;
+  } catch (error) {
+    const err = error as AzureCliTokenProviderError;
+    if (err.code === 'AZURE_CLI_NOT_FOUND') {
+      throw err;
+    }
+
+    if (!interactiveLogin) {
+      throw new AzureCliTokenProviderError(
+        'AZURE_CLI_LOGIN_REQUIRED',
+        'Azure CLI is not logged in.',
+        'Run `az login` first, then retry `agon login --azure-cli --scope <scope>`.',
+      );
+    }
+  }
+
+  try {
+    await runAz(['login', '--use-device-code', '--output', 'none']);
+    await runAz(['account', 'show', '--output', 'none']);
+  } catch (error) {
+    const err = error as AzureCliTokenProviderError;
+    if (err.code === 'AZURE_CLI_NOT_FOUND') {
+      throw err;
+    }
+
+    throw new AzureCliTokenProviderError(
+      'AZURE_CLI_LOGIN_REQUIRED',
+      'Unable to authenticate with Azure CLI.',
+      err.causeDetail,
+    );
+  }
+}
+
+export async function acquireTokenFromAzureCli(options: AzureCliTokenOptions): Promise<string> {
+  const scope = normalizeAzureScope(options.scope);
+  await ensureAzureAccount(options.interactiveLogin ?? false);
+
+  const args = [
+    'account',
+    'get-access-token',
+    '--scope',
+    scope,
+    '--query',
+    'accessToken',
+    '-o',
+    'tsv',
+  ];
+  if (options.tenant?.trim()) {
+    args.push('--tenant', options.tenant.trim());
+  }
+
+  let token: string;
+  try {
+    token = await runAz(args);
+  } catch (error) {
+    const err = error as AzureCliTokenProviderError;
+    if (err.code === 'AZURE_CLI_NOT_FOUND') {
+      throw err;
+    }
+    throw new AzureCliTokenProviderError(
+      'AZURE_CLI_TOKEN_FAILED',
+      'Failed to obtain access token from Azure CLI.',
+      err.causeDetail,
+    );
+  }
+
+  if (!token) {
+    throw new AzureCliTokenProviderError(
+      'AZURE_CLI_TOKEN_FAILED',
+      'Azure CLI returned an empty access token.',
+      'Verify the provided scope and Azure account permissions.',
+    );
+  }
+
+  return token;
+}

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -6,8 +6,9 @@
  *
  * Usage:
  *   agon login
- *   agon login --token <token>   (non-interactive)
- *   agon login --clear           (remove stored token)
+ *   agon login --token <token>                  (non-interactive)
+ *   agon login --azure-cli --scope <scope>      (obtain token via Azure CLI)
+ *   agon login --clear                          (remove stored token)
  */
 
 import { Command, Flags } from '@oclif/core';
@@ -17,6 +18,13 @@ import ora from 'ora';
 import { AuthManager } from '../auth/auth-manager.js';
 import { AgonAPIClient } from '../api/agon-client.js';
 import { ConfigManager } from '../state/config-manager.js';
+import {
+  acquireTokenFromAzureCli,
+  AzureCliTokenProviderError,
+  normalizeAzureScope,
+} from '../auth/azure-cli-token-provider.js';
+
+type TokenSource = 'manual' | 'azure-cli';
 
 export default class Login extends Command {
   static override readonly description =
@@ -25,6 +33,7 @@ export default class Login extends Command {
   static override readonly examples = [
     '<%= config.bin %> login',
     '<%= config.bin %> login --token my-bearer-token',
+    '<%= config.bin %> login --azure-cli --scope api://<app-id>/.default',
     '<%= config.bin %> login --clear'
   ];
 
@@ -32,6 +41,16 @@ export default class Login extends Command {
     token: Flags.string({
       char: 't',
       description: 'Bearer token to save (non-interactive)',
+    }),
+    azureCli: Flags.boolean({
+      description: 'Obtain token from Azure CLI (az account get-access-token)',
+      default: false,
+    }),
+    scope: Flags.string({
+      description: 'OAuth scope/App ID URI for Azure CLI mode (example: api://<app-id>/.default)',
+    }),
+    tenant: Flags.string({
+      description: 'Optional Entra tenant ID for Azure CLI token acquisition',
     }),
     clear: Flags.boolean({
       description: 'Remove any stored bearer token',
@@ -50,13 +69,11 @@ export default class Login extends Command {
     const configManager = new ConfigManager();
     const config = await configManager.load();
 
-    // ── /status: show current auth state ───────────────────────────────
     if (flags.status) {
       await this.showStatus(authManager, config.apiUrl);
       return;
     }
 
-    // ── /clear: remove stored token ─────────────────────────────────────
     if (flags.clear) {
       await authManager.clearToken();
       this.log(chalk.green('✓ Stored authentication token removed.'));
@@ -64,13 +81,11 @@ export default class Login extends Command {
       return;
     }
 
-    // ── Interactive or flag-driven token setup ──────────────────────────
     this.log('');
     this.log(chalk.bold('Agon Authentication Setup'));
     this.log(chalk.dim('─'.repeat(40)));
     this.log('');
 
-    // Warn if backend doesn't require auth
     const authStatus = await this.fetchAuthStatus(config.apiUrl);
     if (authStatus && !authStatus.required) {
       this.log(chalk.yellow('ℹ  The configured backend does not require authentication.'));
@@ -79,37 +94,31 @@ export default class Login extends Command {
       this.log('');
     }
 
-    let token: string;
+    if (flags.token && flags.azureCli) {
+      this.error('Use either --token or --azure-cli, not both.', { exit: 1 });
+    }
 
-    if (flags.token) {
+    const defaultScope = process.env.AGON_AUTH_SCOPE?.trim() ?? process.env.AGON_AUTH_RESOURCE?.trim() ?? '';
+    const scopeFlag = flags.scope?.trim() ?? '';
+    const tenantFlag = flags.tenant?.trim() ?? '';
+
+    let token: string;
+    let tokenSource: TokenSource = 'manual';
+
+    if (flags.azureCli) {
+      token = await this.acquireAzureCliToken(scopeFlag || defaultScope, tenantFlag);
+      tokenSource = 'azure-cli';
+    } else if (flags.token) {
       token = flags.token.trim();
       if (!token) {
         this.error('--token must not be empty.', { exit: 1 });
       }
     } else {
-      this.log('Enter your Agon bearer token below.');
-      this.log(chalk.dim('  Tip: obtain a token from your Agon administrator or identity provider.'));
-      this.log(chalk.dim('  The token is stored in ~/.agon/credentials (mode 0600 — owner read-only).'));
-      this.log('');
-
-      const { inputToken } = await inquirer.prompt<{ inputToken: string }>([
-        {
-          type: 'password',
-          name: 'inputToken',
-          message: 'Bearer token:',
-          mask: '*',
-          validate: (value: string) => {
-            if (!value || value.trim().length === 0) {
-              return 'Token must not be empty.';
-            }
-            return true;
-          }
-        }
-      ]);
-      token = inputToken.trim();
+      const prompted = await this.promptForToken(defaultScope, tenantFlag);
+      token = prompted.token;
+      tokenSource = prompted.source;
     }
 
-    // Verify token against the backend if auth is required
     const spinner = ora({ text: 'Verifying token...', color: 'cyan' }).start();
     try {
       if (authStatus?.required) {
@@ -119,7 +128,6 @@ export default class Login extends Command {
           this.config.pjson.version ?? '0.0.0',
           token
         );
-        // A lightweight call to verify the token is accepted by the backend
         await testClient.listSessions();
       }
       spinner.succeed('Token accepted');
@@ -133,12 +141,14 @@ export default class Login extends Command {
       this.exit(1);
     }
 
-    // Save the token
     await authManager.saveToken(token);
     this.log('');
     this.log(chalk.green('✓ Token saved to ~/.agon/credentials'));
     this.log(chalk.dim('  The token will be used automatically for all future agon commands.'));
     this.log(chalk.dim('  To remove it: agon login --clear'));
+    if (tokenSource === 'azure-cli') {
+      this.log(chalk.dim('  Token source: Azure CLI'));
+    }
   }
 
   private async fetchAuthStatus(
@@ -173,6 +183,7 @@ export default class Login extends Command {
     } else {
       this.log(chalk.yellow('✗ No bearer token configured.'));
       this.log(chalk.dim('  Run `agon login` to save a token, or set AGON_AUTH_TOKEN.'));
+      this.log(chalk.dim('  Azure CLI flow: `agon login --azure-cli --scope api://<app-id>/.default`'));
     }
 
     const authStatus = await this.fetchAuthStatus(apiUrl);
@@ -187,5 +198,105 @@ export default class Login extends Command {
       }
     }
     this.log('');
+  }
+
+  private async promptForToken(defaultScope: string, tenant: string): Promise<{ token: string; source: TokenSource }> {
+    if (!process.stdin.isTTY) {
+      this.error('Non-interactive login requires --token or --azure-cli --scope.', { exit: 1 });
+    }
+
+    const scopeHint = defaultScope || 'api://<app-id>/.default';
+    const { method } = await inquirer.prompt<{ method: TokenSource }>([
+      {
+        type: 'list',
+        name: 'method',
+        message: 'How do you want to sign in?',
+        default: 'azure-cli',
+        choices: [
+          { name: 'Azure CLI (recommended)', value: 'azure-cli' },
+          { name: 'Paste bearer token manually', value: 'manual' },
+        ],
+      },
+    ]);
+
+    if (method === 'azure-cli') {
+      const { scopeInput } = await inquirer.prompt<{ scopeInput: string }>([
+        {
+          type: 'input',
+          name: 'scopeInput',
+          default: scopeHint,
+          message: 'Entra scope or App ID URI:',
+          validate: (value: string) => {
+            try {
+              normalizeAzureScope(value);
+              return true;
+            } catch (error) {
+              return error instanceof Error ? error.message : 'Invalid scope.';
+            }
+          },
+        },
+      ]);
+
+      const token = await this.acquireAzureCliToken(scopeInput, tenant);
+      return { token, source: 'azure-cli' };
+    }
+
+    this.log('');
+    this.log('Enter your Agon bearer token below.');
+    this.log(chalk.dim('  Tip: use Azure CLI flow (`agon login --azure-cli --scope ...`) when possible.'));
+    this.log(chalk.dim('  The token is stored in ~/.agon/credentials (mode 0600 — owner read-only).'));
+    this.log('');
+
+    const { inputToken } = await inquirer.prompt<{ inputToken: string }>([
+      {
+        type: 'password',
+        name: 'inputToken',
+        message: 'Bearer token:',
+        mask: '*',
+        validate: (value: string) => {
+          if (!value || value.trim().length === 0) {
+            return 'Token must not be empty.';
+          }
+          return true;
+        }
+      }
+    ]);
+
+    return { token: inputToken.trim(), source: 'manual' };
+  }
+
+  private async acquireAzureCliToken(scope: string, tenant: string): Promise<string> {
+    let normalizedScope: string;
+    try {
+      normalizedScope = normalizeAzureScope(scope);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.error(message, { exit: 1 });
+    }
+
+    const spinner = ora({ text: `Obtaining token from Azure CLI (${normalizedScope})...`, color: 'cyan' }).start();
+    try {
+      const token = await acquireTokenFromAzureCli({
+        scope: normalizedScope,
+        tenant: tenant || undefined,
+        interactiveLogin: process.stdin.isTTY,
+      });
+      spinner.succeed('Token acquired from Azure CLI');
+      return token;
+    } catch (error) {
+      spinner.fail('Azure CLI token acquisition failed');
+      if (error instanceof AzureCliTokenProviderError) {
+        this.log('');
+        this.log(chalk.red(`✗ ${error.message}`));
+        if (error.causeDetail) {
+          this.log(chalk.dim(`  ${error.causeDetail}`));
+        }
+        this.log('');
+        this.log(chalk.yellow('You can also run: agon login --token "<bearer-token>"'));
+        this.exit(1);
+      }
+
+      throw error;
+    }
   }
 }

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -176,9 +176,10 @@ export default class Shell extends Command {
       this.log('');
       this.log('First-time setup:');
       this.log(`  ${chalk.cyan('agon login')}              Save your bearer token`);
+      this.log(`  ${chalk.cyan('agon login --azure-cli --scope api://<app-id>/.default')}  Obtain token via Azure CLI`);
       this.log(`  ${chalk.cyan('agon login --status')}     Check current auth status`);
       this.log('');
-      this.log(chalk.dim('If you do not have a token, contact your Agon administrator.'));
+      this.log(chalk.dim('Tip: set AGON_AUTH_SCOPE to avoid re-typing the app scope.'));
       this.log('');
       this.exit(1);
     }
@@ -191,6 +192,7 @@ export default class Shell extends Command {
       this.log('');
       this.log('Recommended first-time setup:');
       this.log(`  ${chalk.cyan('agon login')}              Save your bearer token`);
+      this.log(`  ${chalk.cyan('agon login --azure-cli --scope api://<app-id>/.default')}  Obtain token via Azure CLI`);
       this.log(`  ${chalk.cyan('agon login --status')}     Check current auth status`);
       this.log('');
     }

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -116,9 +116,10 @@ export default class Start extends Command {
         this.log('');
         this.log('First-time setup:');
         this.log(`  ${chalk.cyan('agon login')}              Save your bearer token`);
+        this.log(`  ${chalk.cyan('agon login --azure-cli --scope api://<app-id>/.default')}  Obtain token via Azure CLI`);
         this.log(`  ${chalk.cyan('agon login --status')}     Check current auth status`);
         this.log('');
-        this.log(chalk.dim('If you do not have a token, contact your Agon administrator.'));
+        this.log(chalk.dim('Tip: set AGON_AUTH_SCOPE to avoid re-typing the app scope.'));
         this.log(chalk.dim('Local-dev bypass: set AGON_ALLOW_ANONYMOUS=true'));
         this.log('');
         this.exit(1);

--- a/cli/test/auth/azure-cli-token-provider.test.ts
+++ b/cli/test/auth/azure-cli-token-provider.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+import {
+  acquireTokenFromAzureCli,
+  AzureCliTokenProviderError,
+  normalizeAzureScope,
+} from '../../src/auth/azure-cli-token-provider.js';
+
+describe('normalizeAzureScope', () => {
+  it('keeps valid /.default scope unchanged', () => {
+    expect(normalizeAzureScope('api://abc/.default')).toBe('api://abc/.default');
+  });
+
+  it('converts bare UUID to api scope with /.default', () => {
+    expect(normalizeAzureScope('11111111-2222-4333-8444-555555555555'))
+      .toBe('api://11111111-2222-4333-8444-555555555555/.default');
+  });
+
+  it('throws on empty scope', () => {
+    expect(() => normalizeAzureScope('  ')).toThrow(AzureCliTokenProviderError);
+  });
+});
+
+describe('acquireTokenFromAzureCli', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it('returns access token when az account is logged in', async () => {
+    execFileMock.mockImplementation((_: string, args: string[], __: unknown, cb: Function) => {
+      if (args[0] === 'account' && args[1] === 'show') {
+        cb(null, '', '');
+        return;
+      }
+      if (args[0] === 'account' && args[1] === 'get-access-token') {
+        cb(null, 'token-value\n', '');
+        return;
+      }
+      cb(new Error(`Unexpected az args: ${args.join(' ')}`), '', '');
+    });
+
+    const token = await acquireTokenFromAzureCli({
+      scope: 'api://app-id/.default',
+      interactiveLogin: false,
+    });
+
+    expect(token).toBe('token-value');
+  });
+
+  it('performs device-code login when interactive login is enabled and account is missing', async () => {
+    let accountShowCalls = 0;
+    execFileMock.mockImplementation((_: string, args: string[], __: unknown, cb: Function) => {
+      if (args[0] === 'account' && args[1] === 'show') {
+        accountShowCalls += 1;
+        if (accountShowCalls === 1) {
+          const error = Object.assign(new Error('not logged in'), { code: 1 });
+          cb(error, '', 'Please run az login');
+          return;
+        }
+        cb(null, '', '');
+        return;
+      }
+      if (args[0] === 'login') {
+        cb(null, '', '');
+        return;
+      }
+      if (args[0] === 'account' && args[1] === 'get-access-token') {
+        cb(null, 'token-after-login\n', '');
+        return;
+      }
+      cb(new Error(`Unexpected az args: ${args.join(' ')}`), '', '');
+    });
+
+    const token = await acquireTokenFromAzureCli({
+      scope: 'api://app-id/.default',
+      interactiveLogin: true,
+    });
+
+    expect(token).toBe('token-after-login');
+  });
+
+  it('throws login-required when account is missing in non-interactive mode', async () => {
+    execFileMock.mockImplementation((_: string, args: string[], __: unknown, cb: Function) => {
+      if (args[0] === 'account' && args[1] === 'show') {
+        const error = Object.assign(new Error('not logged in'), { code: 1 });
+        cb(error, '', 'Please run az login');
+        return;
+      }
+      cb(new Error(`Unexpected az args: ${args.join(' ')}`), '', '');
+    });
+
+    await expect(acquireTokenFromAzureCli({
+      scope: 'api://app-id/.default',
+      interactiveLogin: false,
+    })).rejects.toMatchObject({
+      code: 'AZURE_CLI_LOGIN_REQUIRED',
+    });
+  });
+
+  it('throws not-found when az CLI is unavailable', async () => {
+    execFileMock.mockImplementation((_: string, __: string[], ___: unknown, cb: Function) => {
+      const error = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      cb(error, '', '');
+    });
+
+    await expect(acquireTokenFromAzureCli({
+      scope: 'api://app-id/.default',
+      interactiveLogin: false,
+    })).rejects.toMatchObject({
+      code: 'AZURE_CLI_NOT_FOUND',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements the user-facing token acquisition workflow directly in CLI login so users do not need to manually source/paste bearer tokens first.

## What changed
- Added Azure CLI token provider:
  - `cli/src/auth/azure-cli-token-provider.ts`
  - Supports `az account get-access-token` with scope normalization.
  - Supports interactive fallback login (`az login --use-device-code`) when needed.
- Extended `agon login` command:
  - New flags:
    - `--azure-cli`
    - `--scope <scope>`
    - `--tenant <tenant-id>`
  - Added interactive method picker:
    - Azure CLI (recommended)
    - Manual bearer token paste
  - Improved error messages and fallback guidance.
- Updated startup guidance in:
  - `start` command auth-required output
  - `shell` command auth-required output
  to include explicit Azure CLI login command.
- Added tests:
  - `cli/test/auth/azure-cli-token-provider.test.ts`
- Updated documentation in README auth setup section.

## Validation
- CLI tests: `574 passed`
- CLI build: `tsc` passes

## Notes
- Includes a changeset:
  - `cli/.changeset/azure-cli-login-workflow.md`
