### PR TITLE
Fix device-code login link + accept Entra audience/issuer variants

### DIFF
--- a/backend/src/Agon.Api/Program.cs
+++ b/backend/src/Agon.Api/Program.cs
@@ -90,6 +90,15 @@ var authAudience = builder.Configuration["Authentication:AzureAd:Audience"] ?? s
 var authClientId = builder.Configuration["Authentication:AzureAd:ClientId"] ?? string.Empty;
 var authInteractiveClientId = builder.Configuration["Authentication:AzureAd:InteractiveClientId"] ?? string.Empty;
 var allowedCorsOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+var normalizedAuthAudience = NormalizeAudience(authAudience);
+var normalizedAuthClientId = NormalizeAudience(authClientId);
+var derivedClientId = ResolveClientIdFromAudience(normalizedAuthAudience);
+var effectiveTenantId = ResolveTenantId(authTenantId, authAuthority);
+
+if (string.IsNullOrWhiteSpace(normalizedAuthClientId) && !string.IsNullOrWhiteSpace(derivedClientId))
+{
+    normalizedAuthClientId = derivedClientId;
+}
 
 if (string.IsNullOrWhiteSpace(authAuthority) && !string.IsNullOrWhiteSpace(authTenantId))
 {
@@ -162,6 +171,9 @@ if (authEnabled)
             "Authentication is enabled but Azure AD JWT settings are incomplete. Configure Authentication:AzureAd:Authority and Authentication:AzureAd:Audience (or ClientId).");
     }
 
+    var validAudiences = BuildValidAudiences(normalizedAuthAudience, normalizedAuthClientId);
+    var validIssuers = BuildValidIssuers(authAuthority, effectiveTenantId);
+
     builder.Services
         .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         .AddJwtBearer(options =>
@@ -172,7 +184,8 @@ if (authEnabled)
             {
                 ValidateIssuer = true,
                 ValidateAudience = true,
-                ValidAudiences = new[] { authAudience, authClientId }.Where(value => !string.IsNullOrWhiteSpace(value))
+                ValidAudiences = validAudiences,
+                ValidIssuers = validIssuers
             };
         });
 
@@ -639,6 +652,98 @@ static string NormalizeSecretValue(string? value)
     }
 
     return value!.Trim();
+}
+
+static string NormalizeAudience(string? value)
+{
+    return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().TrimEnd('/');
+}
+
+static string ResolveClientIdFromAudience(string? audience)
+{
+    if (string.IsNullOrWhiteSpace(audience))
+    {
+        return string.Empty;
+    }
+
+    var trimmed = audience.Trim();
+    if (Guid.TryParse(trimmed, out _))
+    {
+        return trimmed;
+    }
+
+    const string prefix = "api://";
+    if (trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+    {
+        var candidate = trimmed[prefix.Length..].Trim('/');
+        return Guid.TryParse(candidate, out _) ? candidate : string.Empty;
+    }
+
+    return string.Empty;
+}
+
+static IEnumerable<string> BuildValidAudiences(string? audience, string? clientId)
+{
+    var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (!string.IsNullOrWhiteSpace(audience))
+    {
+        values.Add(audience.Trim().TrimEnd('/'));
+    }
+    if (!string.IsNullOrWhiteSpace(clientId))
+    {
+        var normalizedClientId = clientId.Trim();
+        values.Add(normalizedClientId);
+        values.Add($"api://{normalizedClientId}");
+    }
+    return values;
+}
+
+static string ResolveTenantId(string? tenantId, string? authority)
+{
+    if (!string.IsNullOrWhiteSpace(tenantId))
+    {
+        return tenantId.Trim();
+    }
+
+    if (string.IsNullOrWhiteSpace(authority))
+    {
+        return string.Empty;
+    }
+
+    if (!Uri.TryCreate(authority.Trim(), UriKind.Absolute, out var authorityUri))
+    {
+        return string.Empty;
+    }
+
+    var firstSegment = authorityUri.AbsolutePath
+        .Split('/')
+        .Select(segment => segment.Trim())
+        .FirstOrDefault(segment => !string.IsNullOrWhiteSpace(segment)) ?? string.Empty;
+
+    if (string.IsNullOrWhiteSpace(firstSegment))
+    {
+        return string.Empty;
+    }
+
+    return firstSegment;
+}
+
+static IEnumerable<string>? BuildValidIssuers(string? authority, string? tenantId)
+{
+    var values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    if (!string.IsNullOrWhiteSpace(authority))
+    {
+        values.Add(authority.Trim().TrimEnd('/'));
+    }
+
+    if (!string.IsNullOrWhiteSpace(tenantId))
+    {
+        var trimmedTenant = tenantId.Trim();
+        values.Add($"https://login.microsoftonline.com/{trimmedTenant}/v2.0");
+        values.Add($"https://sts.windows.net/{trimmedTenant}/");
+    }
+
+    return values.Count > 0 ? values : null;
 }
 
 static RateLimitPartition<string> BuildFixedWindowRateLimiter(

--- a/cli/.changeset/login-device-code-fixes.md
+++ b/cli/.changeset/login-device-code-fixes.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Make device-code sign-in link clickable and improve login messaging.

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -34,6 +34,7 @@ import {
   acquireTokenFromEntraDeviceCode,
   EntraDeviceCodeTokenProviderError,
 } from '../auth/entra-device-code-token-provider.js';
+import { formatTerminalLink } from '../utils/terminal-links.js';
 
 type TokenSource = 'manual' | 'azure-cli' | 'device-code';
 
@@ -437,9 +438,10 @@ export default class Login extends Command {
         scope: normalizedScope,
         onUserPrompt: (prompt) => {
           spinner.stop();
+          const deviceUrl = prompt.verificationUriComplete || prompt.verificationUri;
           this.log('');
           this.log(chalk.bold('Complete sign-in in your browser'));
-          this.log(chalk.cyan(`1. Open: ${prompt.verificationUriComplete || prompt.verificationUri}`));
+          this.log(`${chalk.cyan('1. Open:')} ${formatTerminalLink(deviceUrl)}`);
           this.log(chalk.cyan(`2. Enter code: ${prompt.userCode}`));
           if (prompt.message) {
             this.log(chalk.dim(prompt.message));

--- a/cli/src/utils/terminal-links.ts
+++ b/cli/src/utils/terminal-links.ts
@@ -1,0 +1,25 @@
+const OSC = '\u001B]8;;';
+const BEL = '\u0007';
+const OSC_END = '\u001B]8;;\u0007';
+
+export function formatTerminalLink(url: string, label?: string): string {
+  const text = label ?? url;
+  if (!supportsHyperlinks()) {
+    return text;
+  }
+  return `${OSC}${url}${BEL}${text}${OSC_END}`;
+}
+
+function supportsHyperlinks(): boolean {
+  if (!process.stdout.isTTY) {
+    return false;
+  }
+  const term = (process.env.TERM ?? '').toLowerCase();
+  if (!term || term === 'dumb') {
+    return false;
+  }
+  if (process.env.TERM_NO_HYPERLINKS === '1') {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- make Entra device-code URL clickable in CLI output
- accept `api://<app-id>` and raw `<app-id>` audiences, plus v1/v2 issuers, during JWT validation
- add CLI changeset

## Testing
- `npm test` (cli)
- `dotnet test backend/Agon.sln`