### PR TITLE
fix(ci): make codex review post reliably and skip Dependabot PRs

### DIFF
--- a/.github/scripts/codex-pr-review.mjs
+++ b/.github/scripts/codex-pr-review.mjs
@@ -16,6 +16,17 @@ if (!pr) {
   process.exit(1);
 }
 
+const prAuthor = pr.user?.login || '';
+const isDependabotPr =
+  prAuthor === 'dependabot[bot]' ||
+  process.env.GITHUB_ACTOR === 'dependabot[bot]' ||
+  (pr.head?.ref || '').startsWith('dependabot/');
+
+if (isDependabotPr) {
+  console.log('Dependabot PR detected; skipping Codex review by design.');
+  process.exit(0);
+}
+
 const repoSlug = process.env.GITHUB_REPOSITORY || '';
 const [owner, repo] = repoSlug.split('/');
 if (!owner || !repo) {
@@ -119,7 +130,7 @@ const openAiResponse = await fetch('https://api.openai.com/v1/chat/completions',
   body: JSON.stringify({
     model,
     temperature: 0.2,
-    max_tokens: 1500,
+    max_completion_tokens: 1500,
     messages: [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: userPrompt },

--- a/.github/workflows/ensure-codex-ruleset.yaml
+++ b/.github/workflows/ensure-codex-ruleset.yaml
@@ -1,8 +1,8 @@
 name: Ensure Codex Review Ruleset
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -13,7 +13,6 @@ jobs:
     name: Ensure Codex Review Required
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.pull_request.base.ref == 'main' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- fix Codex review script to use max_completion_tokens with GPT-5 models
- skip Codex review execution for Dependabot PRs (pass check without posting review)
- stop running ruleset-enforcement workflow on PR events; run on push to main and manual dispatch only

## Why
PRs #310-#327 show the review workflow triggering but failing before posting any review. This change unblocks normal PR reviews and removes noisy/failing checks on Dependabot updates.

## Validation
- node --check .github/scripts/codex-pr-review.mjs
- local pre-commit hooks passed (CLI + backend tests)
