### PR TITLE
fix(ci): restore ensure-codex and update-badges pipelines

### DIFF
--- a/.github/scripts/ensure-codex-ruleset.mjs
+++ b/.github/scripts/ensure-codex-ruleset.mjs
@@ -19,24 +19,24 @@ const githubApi = process.env.GITHUB_API_URL || 'https://api.github.com';
 const rulesetName = process.env.CODEX_RULESET_NAME || 'Require Codex Review';
 const requiredCheck = process.env.CODEX_REVIEW_CHECK || 'Codex Review';
 const targetBranch = process.env.CODEX_RULESET_BRANCH || 'refs/heads/main';
-const githubActionsAppId = Number.parseInt(
-  process.env.CODEX_BYPASS_GITHUB_ACTIONS_APP_ID || '15368',
+const bypassRepositoryRoleId = Number.parseInt(
+  process.env.CODEX_BYPASS_REPOSITORY_ROLE_ID || '5',
   10,
 );
 
 function ensureBypassActors(existingBypassActors = []) {
   const actors = Array.isArray(existingBypassActors) ? [...existingBypassActors] : [];
-  const hasGitHubActionsBypass = actors.some(
+  const hasRepositoryRoleBypass = actors.some(
     (actor) =>
-      actor?.actor_type === 'Integration' &&
-      Number(actor?.actor_id) === githubActionsAppId &&
+      actor?.actor_type === 'RepositoryRole' &&
+      Number(actor?.actor_id) === bypassRepositoryRoleId &&
       actor?.bypass_mode === 'always',
   );
 
-  if (!hasGitHubActionsBypass) {
+  if (!hasRepositoryRoleBypass) {
     actors.push({
-      actor_id: githubActionsAppId,
-      actor_type: 'Integration',
+      actor_id: bypassRepositoryRoleId,
+      actor_type: 'RepositoryRole',
       bypass_mode: 'always',
     });
   }

--- a/.github/workflows/ensure-codex-ruleset.yaml
+++ b/.github/workflows/ensure-codex-ruleset.yaml
@@ -24,5 +24,5 @@ jobs:
           CODEX_RULESET_NAME: Require Codex Review
           CODEX_REVIEW_CHECK: Codex Review
           CODEX_RULESET_BRANCH: refs/heads/main
-          CODEX_BYPASS_GITHUB_ACTIONS_APP_ID: "15368"
+          CODEX_BYPASS_REPOSITORY_ROLE_ID: "5"
         run: node .github/scripts/ensure-codex-ruleset.mjs

--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -129,6 +129,8 @@ jobs:
             "README.md"
 
       - name: Commit updated badges
+        env:
+          REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -137,8 +139,11 @@ jobs:
             echo "No badge changes to commit."
           else
             git commit -m "chore: update test & coverage badges [skip ci]"
+            if [ -n "${REPO_ADMIN_TOKEN}" ]; then
+              git remote set-url origin "https://x-access-token:${REPO_ADMIN_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            fi
             if ! git push origin HEAD:main; then
-              echo "::error::Failed to push badge update to main. Ensure workflow permissions include contents: write and branch protection allows github-actions[bot] to push."
+              echo "::error::Failed to push badge update to main. Ensure REPO_ADMIN_TOKEN is configured and ruleset bypass includes repository admin role."
               exit 1
             fi
           fi


### PR DESCRIPTION
Summary:
- Replace unsupported Integration bypass in ruleset automation with RepositoryRole bypass (admin role id 5)
- Keep Codex Review required on main
- Update Update Badges push step to use REPO_ADMIN_TOKEN when available (so bot updates can push under ruleset)

Why:
- Ensure Codex Ruleset was failing with GitHub API 422 due invalid Integration bypass actor.
- Update Badges was failing with GH013 because direct push to main could not satisfy required Codex Review check.

Validation:
- node --check .github/scripts/ensure-codex-ruleset.mjs
- local pre-commit test gates passed (CLI + backend suites)
