### PR TITLE
fix(ci): make Update Badges use PAT auth reliably

### DIFF
--- a/.github/scripts/ensure-codex-ruleset.mjs
+++ b/.github/scripts/ensure-codex-ruleset.mjs
@@ -20,7 +20,7 @@ const rulesetName = process.env.CODEX_RULESET_NAME || 'Require Codex Review';
 const requiredCheck = process.env.CODEX_REVIEW_CHECK || 'Codex Review';
 const targetBranch = process.env.CODEX_RULESET_BRANCH || 'refs/heads/main';
 const bypassRepositoryRoleId = Number.parseInt(
-  process.env.CODEX_BYPASS_REPOSITORY_ROLE_ID || '5',
+  process.env.CODEX_BYPASS_REPOSITORY_ROLE_ID || '2',
   10,
 );
 

--- a/.github/workflows/ensure-codex-ruleset.yaml
+++ b/.github/workflows/ensure-codex-ruleset.yaml
@@ -24,5 +24,5 @@ jobs:
           CODEX_RULESET_NAME: Require Codex Review
           CODEX_REVIEW_CHECK: Codex Review
           CODEX_RULESET_BRANCH: refs/heads/main
-          CODEX_BYPASS_REPOSITORY_ROLE_ID: "5"
+          CODEX_BYPASS_REPOSITORY_ROLE_ID: "2"
         run: node .github/scripts/ensure-codex-ruleset.mjs

--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -140,10 +140,11 @@ jobs:
           else
             git commit -m "chore: update test & coverage badges [skip ci]"
             if [ -n "${REPO_ADMIN_TOKEN}" ]; then
+              git config --local --unset-all http.https://github.com/.extraheader || true
               git remote set-url origin "https://x-access-token:${REPO_ADMIN_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             fi
             if ! git push origin HEAD:main; then
-              echo "::error::Failed to push badge update to main. Ensure REPO_ADMIN_TOKEN is configured and ruleset bypass includes repository admin role."
+              echo "::error::Failed to push badge update to main. Ensure REPO_ADMIN_TOKEN is configured and ruleset bypass includes the configured repository role."
               exit 1
             fi
           fi


### PR DESCRIPTION
Fixes remaining GH013 failures in Update Badges by unsetting checkout auth header before push, then pushing with REPO_ADMIN_TOKEN auth; also aligns ruleset bypass role id to 2.