### PR TITLE
fix(ci): deterministic Update Badges push + changeset Codex bypass

### DIFF
--- a/.github/scripts/codex-pr-review.mjs
+++ b/.github/scripts/codex-pr-review.mjs
@@ -17,13 +17,23 @@ if (!pr) {
 }
 
 const prAuthor = pr.user?.login || '';
+const headRef = pr.head?.ref || '';
 const isDependabotPr =
   prAuthor === 'dependabot[bot]' ||
   process.env.GITHUB_ACTOR === 'dependabot[bot]' ||
-  (pr.head?.ref || '').startsWith('dependabot/');
+  headRef.startsWith('dependabot/');
+
+const isChangesetReleasePr =
+  headRef.startsWith('changeset-release/') ||
+  (prAuthor === 'github-actions[bot]' && /^Version Packages/i.test(pr.title || ''));
 
 if (isDependabotPr) {
   console.log('Dependabot PR detected; skipping Codex review by design.');
+  process.exit(0);
+}
+
+if (isChangesetReleasePr) {
+  console.log('Changeset release PR detected; bypassing Codex review by design.');
   process.exit(0);
 }
 

--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -138,11 +139,13 @@ jobs:
           if git diff --cached --quiet; then
             echo "No badge changes to commit."
           else
-            git commit -m "chore: update test & coverage badges [skip ci]"
-            if [ -n "${REPO_ADMIN_TOKEN}" ]; then
-              git config --local --unset-all http.https://github.com/.extraheader || true
-              git remote set-url origin "https://x-access-token:${REPO_ADMIN_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            if [ -z "${REPO_ADMIN_TOKEN}" ]; then
+              echo "::error::REPO_ADMIN_TOKEN is required for deterministic pushes to protected main."
+              exit 1
             fi
+            git commit -m "chore: update test & coverage badges [skip ci]"
+            git config --local --unset-all http.https://github.com/.extraheader || true
+            git remote set-url origin "https://x-access-token:${REPO_ADMIN_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             if ! git push origin HEAD:main; then
               echo "::error::Failed to push badge update to main. Ensure REPO_ADMIN_TOKEN is configured and ruleset bypass includes the configured repository role."
               exit 1


### PR DESCRIPTION
## Summary
- make  push deterministic on protected 
  - set  
  - require  for badge push
  - push using PAT-authenticated remote only
- bypass Codex review for changeset release PRs ( and bot version PR pattern)

## Why
-  was failing with  under required  ruleset.
- changeset release PRs should not be blocked by Codex review.

## Validation
- local CLI tests and backend tests pass via commit hooks
