### PR TITLE
feat(ci): enforce rubric-backed Codex PR reviews

### DIFF
--- a/.github/review-rubrics/clean-architecture.md
+++ b/.github/review-rubrics/clean-architecture.md
@@ -1,0 +1,11 @@
+Boundary discipline:
+- Check dependency direction: policy/core should not depend on delivery/framework/infrastructure details.
+- Verify adapters translate external formats cleanly without leaking them into core rules.
+
+Design integrity:
+- Identify architecture drift, mixed responsibilities, and coupling across layers.
+- Validate interfaces/contracts are explicit and stable for changed boundaries.
+
+Operational architecture concerns:
+- Review migrations/deploy sequencing and failure modes for safe rollout.
+- Prefer incremental, reversible changes when boundaries or contracts move.

--- a/.github/review-rubrics/clean-code.md
+++ b/.github/review-rubrics/clean-code.md
@@ -1,0 +1,12 @@
+Readability and intent:
+- Prefer clear naming and direct control flow over cleverness.
+- Keep diffs focused and responsibilities narrow.
+
+Correctness and reliability:
+- Ensure error paths are explicit and actionable.
+- Flag hidden side effects, unclear state transitions, and fragile branching.
+
+Testing and maintainability:
+- Expect tests that prove behavior, not only happy paths.
+- Call out missing edge-case coverage for changed logic.
+- Prefer minimal, safe fixes over broad refactors unless necessary.

--- a/.github/review-rubrics/pull-request-review.md
+++ b/.github/review-rubrics/pull-request-review.md
@@ -1,0 +1,13 @@
+Scope and risk triage:
+- Prioritize behavior, security, and operational risk before style.
+- Increase depth for auth, secrets, data integrity, migrations, infra, networking, and public API changes.
+
+Required review method:
+- Validate critical paths end-to-end, including error and rollback paths.
+- Prefer concrete, code-backed findings over speculation.
+- Check observability, rollout safety, and backward compatibility on risky changes.
+
+Finding quality bar:
+- Each finding must include Severity, Title, Evidence, Impact, Fix.
+- Order findings by severity: Critical, High, Medium, Low.
+- If no blockers exist, state that explicitly and list residual risks/testing gaps.

--- a/.github/scripts/codex-pr-review-core.mjs
+++ b/.github/scripts/codex-pr-review-core.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+
+const RUBRIC_FILE_MAP = {
+  pullRequestReview: 'pull-request-review.md',
+  cleanCode: 'clean-code.md',
+  cleanArchitecture: 'clean-architecture.md',
+};
+
+export function isDependabotPr(pr, actor = '') {
+  const author = pr?.user?.login || '';
+  const headRef = pr?.head?.ref || '';
+  return author === 'dependabot[bot]' || actor === 'dependabot[bot]' || headRef.startsWith('dependabot/');
+}
+
+export function isChangesetReleasePr(pr) {
+  const author = pr?.user?.login || '';
+  const headRef = pr?.head?.ref || '';
+  const title = pr?.title || '';
+  return headRef.startsWith('changeset-release/') || (author === 'github-actions[bot]' && /^Version Packages/i.test(title));
+}
+
+export function loadSkillRubrics(baseDir = process.cwd()) {
+  const rubricDirectory = path.join(baseDir, '.github', 'review-rubrics');
+  const rubrics = {};
+
+  for (const [key, fileName] of Object.entries(RUBRIC_FILE_MAP)) {
+    const filePath = path.join(rubricDirectory, fileName);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Missing rubric file: ${filePath}`);
+    }
+
+    const content = fs.readFileSync(filePath, 'utf8').trim();
+    if (!content) {
+      throw new Error(`Empty rubric file: ${filePath}`);
+    }
+
+    rubrics[key] = content;
+  }
+
+  return rubrics;
+}
+
+export function buildSystemPrompt(rubrics) {
+  return [
+    'You are Codex performing a rigorous PR review.',
+    'Treat the following rubric documents as mandatory instructions and apply them in this order.',
+    'If rubrics conflict, prioritize security/correctness over style.',
+    'Do not make speculative findings without evidence in the diff.',
+    '',
+    'RUBRIC 1: pull-request-review',
+    rubrics.pullRequestReview,
+    '',
+    'RUBRIC 2: clean-code',
+    rubrics.cleanCode,
+    '',
+    'RUBRIC 3: clean-architecture',
+    rubrics.cleanArchitecture,
+    '',
+    'Output contract:',
+    '- Findings first, ordered by severity (Critical, High, Medium, Low).',
+    '- Each finding must include Severity, Title, Evidence, Impact, Fix.',
+    '- If no findings: output "No blocking issues found" and list residual risks/testing gaps.',
+  ].join('\n');
+}
+
+export function buildUserPrompt(pr, diff, maxDiffChars, diffTruncated) {
+  const prInfo = [
+    `Title: ${pr?.title || ''}`,
+    `Author: ${pr?.user?.login || 'unknown'}`,
+    `Base: ${pr?.base?.ref || ''}`,
+    `Head: ${pr?.head?.ref || ''}`,
+    'Body:',
+    pr?.body || '(no description)',
+  ].join('\n');
+
+  const truncationNote = diffTruncated
+    ? `\n[Diff truncated at ${maxDiffChars} characters. Focus on highest-risk changes first.]`
+    : '';
+
+  return [
+    'Review the following pull request diff.',
+    '',
+    prInfo,
+    '',
+    'Diff:',
+    diff,
+    truncationNote,
+  ].join('\n');
+}
+

--- a/.github/scripts/codex-pr-review-core.test.mjs
+++ b/.github/scripts/codex-pr-review-core.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildSystemPrompt,
+  buildUserPrompt,
+  isChangesetReleasePr,
+  isDependabotPr,
+  loadSkillRubrics,
+} from './codex-pr-review-core.mjs';
+
+test('isDependabotPr returns true for dependabot branch', () => {
+  const pr = {
+    user: { login: 'octocat' },
+    head: { ref: 'dependabot/npm_and_yarn/typescript-6.0.2' },
+  };
+  assert.equal(isDependabotPr(pr, ''), true);
+});
+
+test('isChangesetReleasePr returns true for changeset-release branch', () => {
+  const pr = {
+    user: { login: 'github-actions[bot]' },
+    head: { ref: 'changeset-release/main' },
+    title: 'Version Packages',
+  };
+  assert.equal(isChangesetReleasePr(pr), true);
+});
+
+test('loadSkillRubrics reads rubric files from repository-like tree', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-review-rubrics-'));
+  const rubricDir = path.join(tempRoot, '.github', 'review-rubrics');
+  fs.mkdirSync(rubricDir, { recursive: true });
+  fs.writeFileSync(path.join(rubricDir, 'pull-request-review.md'), 'pull request rubric');
+  fs.writeFileSync(path.join(rubricDir, 'clean-code.md'), 'clean code rubric');
+  fs.writeFileSync(path.join(rubricDir, 'clean-architecture.md'), 'clean architecture rubric');
+
+  const rubrics = loadSkillRubrics(tempRoot);
+  assert.equal(rubrics.pullRequestReview, 'pull request rubric');
+  assert.equal(rubrics.cleanCode, 'clean code rubric');
+  assert.equal(rubrics.cleanArchitecture, 'clean architecture rubric');
+});
+
+test('buildSystemPrompt includes all rubric sections', () => {
+  const prompt = buildSystemPrompt({
+    pullRequestReview: 'A',
+    cleanCode: 'B',
+    cleanArchitecture: 'C',
+  });
+
+  assert.match(prompt, /RUBRIC 1: pull-request-review/);
+  assert.match(prompt, /RUBRIC 2: clean-code/);
+  assert.match(prompt, /RUBRIC 3: clean-architecture/);
+  assert.match(prompt, /A/);
+  assert.match(prompt, /B/);
+  assert.match(prompt, /C/);
+});
+
+test('buildUserPrompt includes truncation note when diff was truncated', () => {
+  const pr = {
+    title: 'T',
+    user: { login: 'u' },
+    base: { ref: 'main' },
+    head: { ref: 'feature/x' },
+    body: 'desc',
+  };
+  const prompt = buildUserPrompt(pr, 'diff', 123, true);
+  assert.match(prompt, /Diff truncated at 123 characters/);
+});
+

--- a/.github/scripts/codex-pr-review.mjs
+++ b/.github/scripts/codex-pr-review.mjs
@@ -2,6 +2,13 @@
 
 import fs from 'fs';
 import process from 'process';
+import {
+  buildSystemPrompt,
+  buildUserPrompt,
+  isChangesetReleasePr,
+  isDependabotPr,
+  loadSkillRubrics,
+} from './codex-pr-review-core.mjs';
 
 const eventPath = process.env.GITHUB_EVENT_PATH;
 if (!eventPath) {
@@ -16,23 +23,12 @@ if (!pr) {
   process.exit(1);
 }
 
-const prAuthor = pr.user?.login || '';
-const headRef = pr.head?.ref || '';
-const isDependabotPr =
-  prAuthor === 'dependabot[bot]' ||
-  process.env.GITHUB_ACTOR === 'dependabot[bot]' ||
-  headRef.startsWith('dependabot/');
-
-const isChangesetReleasePr =
-  headRef.startsWith('changeset-release/') ||
-  (prAuthor === 'github-actions[bot]' && /^Version Packages/i.test(pr.title || ''));
-
-if (isDependabotPr) {
+if (isDependabotPr(pr, process.env.GITHUB_ACTOR || '')) {
   console.log('Dependabot PR detected; skipping Codex review by design.');
   process.exit(0);
 }
 
-if (isChangesetReleasePr) {
+if (isChangesetReleasePr(pr)) {
   console.log('Changeset release PR detected; bypassing Codex review by design.');
   process.exit(0);
 }
@@ -92,44 +88,9 @@ if (diff.length > maxDiffChars) {
   diffTruncated = true;
 }
 
-const prInfo = [
-  `Title: ${pr.title}`,
-  `Author: ${pr.user?.login || 'unknown'}`,
-  `Base: ${pr.base?.ref || ''}`,
-  `Head: ${pr.head?.ref || ''}`,
-  'Body:',
-  pr.body || '(no description)',
-].join('\n');
-
-const truncationNote = diffTruncated
-  ? `\n[Diff truncated at ${maxDiffChars} characters. Focus on highest-risk changes first.]`
-  : '';
-
-const systemPrompt = [
-  'You are Codex performing a rigorous PR review.',
-  'Apply three rubrics in this order:',
-  '1) pull-request-review: risk-based, behavior-first, findings ordered by severity, include evidence and fixes.',
-  '2) clean-code: clarity, naming, error handling, readability, and test quality.',
-  '3) clean-architecture: boundaries, dependency direction, adapter separation, and policy isolation.',
-  'Do not approve speculative issues without evidence in the diff.',
-  'If no issues found, say "No blocking issues found" and list residual risks/testing gaps.',
-].join(' ');
-
-const userPrompt = [
-  'Review the following PR diff.',
-  '',
-  prInfo,
-  '',
-  'Diff:',
-  diff,
-  truncationNote,
-  '',
-  'Respond in Markdown with:',
-  '1. Findings (each with Severity, Title, Evidence, Impact, Fix)',
-  '2. Summary (short)',
-  '3. Tests/Verification (what was run / missing)',
-  '4. Risks/Follow-ups (if any)',
-].join('\n');
+const rubrics = loadSkillRubrics(process.cwd());
+const systemPrompt = buildSystemPrompt(rubrics);
+const userPrompt = buildUserPrompt(pr, diff, maxDiffChars, diffTruncated);
 
 const openAiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
   method: 'POST',

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,22 @@ on:
     branches: [main]
 
 jobs:
+  codex-review-tests:
+    name: Codex Review Script Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Run Codex review script tests
+        run: node --test .github/scripts/codex-pr-review-core.test.mjs
+
   cli-changeset:
     name: CLI Changeset Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What this changes
- replaces label-only prompt usage with rubric-backed prompt composition from versioned files in repo:
  - .github/review-rubrics/pull-request-review.md
  - .github/review-rubrics/clean-code.md
  - .github/review-rubrics/clean-architecture.md
- refactors review logic into tested core module:
  - .github/scripts/codex-pr-review-core.mjs
- keeps existing bypass behavior for dependabot and changeset release PRs
- adds automated tests for review-core behavior and wires them into CI

## Why
Previously, the review script only referenced skill names in plain text. This change makes the LLM consume concrete rubric content from files under version control.

## Validation
- node --test .github/scripts/codex-pr-review-core.test.mjs
- node --check .github/scripts/codex-pr-review.mjs
- full commit hooks passed (CLI tests + backend tests)
