### PR TITLE
fix(cli): codex-style multiline input rendering

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -32,11 +32,15 @@ else
   echo "⏭️  No CLI project found — skipping CLI tests."
 fi
 
-# Backend tests — only run if a .NET project exists
+# Backend tests — run explicit solution path for deterministic behavior
 if find backend -name '*.sln' -o -name '*.csproj' 2>/dev/null | grep -q .; then
   echo ""
   echo "🧪 Running backend tests before commit..."
-  cd backend && dotnet test --verbosity quiet
+  DOTNET_CMD="/usr/local/share/dotnet/dotnet"
+  if [ ! -x "$DOTNET_CMD" ]; then
+    DOTNET_CMD="dotnet"
+  fi
+  DOTNET_CLI_HOME=/tmp "$DOTNET_CMD" test backend/Agon.sln --verbosity minimal
 
   if [ $? -ne 0 ]; then
     echo "❌ Backend tests failed. Commit aborted."

--- a/cli/.changeset/calm-plums-beg.md
+++ b/cli/.changeset/calm-plums-beg.md
@@ -1,0 +1,5 @@
+---
+'@agon_agents/cli': patch
+---
+
+Align shell multiline prompt rendering with Codex-style behavior by starting compact and expanding as input wraps, while preserving readable wrapping and overlay placement.

--- a/cli/src/shell/renderer.ts
+++ b/cli/src/shell/renderer.ts
@@ -138,7 +138,8 @@ export function renderPromptBanner(
     cursorDownFromFirstLine: frame.inputLineCount + 1,
     inputLineCount: frame.inputLineCount,
     promptLineOffset: frame.promptLineOffset,
-    maxInputCharsPerLine: Math.max(1, frame.width - frame.promptPrefix.length),
+    // Keep a small right gutter so wrapped lines do not visually collide with the frame edge.
+    maxInputCharsPerLine: Math.max(1, frame.width - frame.promptPrefix.length - 1),
     // Input is unbounded; renderer keeps the cursor-visible window in frame.
     maxInputChars: Number.MAX_SAFE_INTEGER,
     promptPrefix: frame.promptPrefix,
@@ -167,7 +168,8 @@ export function buildPromptInputLineWithCursor(
   cursorIndex: number,
   options?: PromptRenderOptions
 ): string {
-  const editableLineCount = getEditableLineCount(frame);
+  const overlayLineCount = options?.topOverlayText ? 1 : 0;
+  const editableLineCount = Math.max(1, frame.inputLineCount - overlayLineCount);
   const visibleValue = getVisiblePromptValue(value, frame.maxInputChars);
   const visibleCursorIndex = getVisibleCursorIndex(value, visibleValue, cursorIndex);
   const wrapped = wrapPromptValue(visibleValue, frame.maxInputCharsPerLine);
@@ -187,7 +189,7 @@ export function buildPromptInputLineWithCursor(
     const chunk = chunks[index] ?? '';
     const prefix = index === 0 ? frame.promptPrefix : frame.promptContinuationPrefix;
     const content = `${prefix}${chunk}`.padEnd(frame.width, ' ');
-    const visualLineIndex = frame.promptLineOffset + index;
+    const visualLineIndex = frame.promptLineOffset + overlayLineCount + index;
     if (visualLineIndex < frame.inputLineCount) {
       lines[visualLineIndex] = `${frame.promptStart}${content}${frame.reset}`;
     }
@@ -197,7 +199,7 @@ export function buildPromptInputLineWithCursor(
   const cursorColumn = cursorPosition.column;
   const cursorPrefix = cursorEditableLineIndex === 0 ? frame.promptPrefix : frame.promptContinuationPrefix;
   const cursorText = (chunks[cursorEditableLineIndex] ?? '').slice(0, cursorColumn);
-  const cursorLineIndex = frame.promptLineOffset + cursorEditableLineIndex;
+  const cursorLineIndex = frame.promptLineOffset + overlayLineCount + cursorEditableLineIndex;
   const linesBelowCursor = frame.inputLineCount - cursorLineIndex - 1;
   const moveUp = linesBelowCursor > 0 ? `\u001b[${linesBelowCursor}A` : '';
 
@@ -313,10 +315,9 @@ function createPromptFrame(inputLineCountOverride?: number): PromptFrame {
   const terminalWidth = process.stdout.columns ?? 100;
   // Codex-like wide prompt zone: keep a small side margin, but avoid runaway ultra-wide lines.
   const width = Math.max(72, Math.min(terminalWidth - 4, 180));
-  // Keep the landing zone compact (Codex-style): 1 blank above and 1 blank below the prompt so
-  // the `>` marker is vertically centered in the idle input box.
-  const inputLineCount = Math.max(3, inputLineCountOverride ?? 3);
-  const promptLineOffset = 1;
+  // Start as a single prompt row and let the frame grow with input.
+  const inputLineCount = Math.max(1, inputLineCountOverride ?? 1);
+  const promptLineOffset = 0;
   const borderLine = chalk.whiteBright('─'.repeat(width));
   const backgroundStart = '\u001b[48;2;63;111;201m';
   const promptStart = `${backgroundStart}\u001b[97m`;

--- a/cli/test/shell/renderer.test.ts
+++ b/cli/test/shell/renderer.test.ts
@@ -70,16 +70,13 @@ describe('shell renderer', () => {
     expect(frame.maxInputChars).toBeGreaterThan(0);
     expect(frame.cursorUpLines).toBe(frame.inputLineCount + 1);
     expect(frame.cursorDownFromFirstLine).toBe(frame.inputLineCount + 1);
-    expect(frame.inputLineCount).toBe(3);
-    expect(frame.promptLineOffset).toBe(1);
+    expect(frame.inputLineCount).toBe(1);
+    expect(frame.promptLineOffset).toBe(0);
   });
 
-  it('centers > prompt vertically in the idle input box (equal blank lines above and below)', () => {
+  it('starts prompt on the first input row (Codex-like compact input zone)', () => {
     const frame = renderPromptBanner(() => {});
-    const blankLinesAbove = frame.promptLineOffset;
-    const blankLinesBelow = frame.inputLineCount - frame.promptLineOffset - 1;
-
-    expect(blankLinesAbove).toBe(blankLinesBelow);
+    expect(frame.promptLineOffset).toBe(0);
   });
 
   it('builds an active prompt line with an input cursor prefix', () => {
@@ -89,8 +86,7 @@ describe('shell renderer', () => {
     const rows = plain.split('\n');
 
     expect(prompt).toContain('\u001b[48;2;63;111;201m');
-    expect(rows[0]).not.toContain('> ');
-    expect(rows[1]).toContain('  > ');
+    expect(rows[0]).toContain('  > ');
   });
 
   it('builds shimmer text variants while preserving visible message', () => {
@@ -123,28 +119,28 @@ describe('shell renderer', () => {
   });
 
   it('wraps prompt input across multiple lines inside the frame', () => {
-    const frame = renderPromptBanner(() => {});
+    const frame = renderPromptBanner(() => {}, { inputLineCount: 3 });
     const longValue = 'a'.repeat(frame.maxInputCharsPerLine + 10);
     const rendered = buildPromptInputLine(frame, longValue);
 
     expect(rendered).toContain('\n');
-    expect(getPromptCursorPosition(frame, longValue, longValue.length).lineIndex).toBe(2);
+    expect(getPromptCursorPosition(frame, longValue, longValue.length).lineIndex).toBe(1);
   });
 
   it('wraps on word boundaries when space is available', () => {
-    const frame = renderPromptBanner(() => {});
+    const frame = renderPromptBanner(() => {}, { inputLineCount: 3 });
     const firstLine = 'a'.repeat(frame.maxInputCharsPerLine - 2);
     const value = `${firstLine} alpha beta`;
     const rendered = buildPromptInputLine(frame, value);
     const plain = rendered.replace(/\u001b\[[0-9;]*m/g, '');
     const rows = plain.split('\n');
 
-    expect(rows[1]).not.toContain('alph');
-    expect(rows[2]).toContain('alpha beta');
+    expect(rows[0]).not.toContain('alph');
+    expect(rows[1]).toContain('alpha beta');
   });
 
   it('keeps cursor visible at bottom of prompt viewport for very long input', () => {
-    const frame = renderPromptBanner(() => {});
+    const frame = renderPromptBanner(() => {}, { inputLineCount: 3 });
     const longValue = 'word '.repeat(frame.maxInputCharsPerLine * 2);
     const cursor = getPromptCursorPosition(frame, longValue, longValue.length);
     const expectedLastLine = frame.promptLineOffset + (frame.inputLineCount - frame.promptLineOffset) - 1;
@@ -164,7 +160,7 @@ describe('shell renderer', () => {
   });
 
   it('renders top overlay text for live attachment preview', () => {
-    const frame = renderPromptBanner(() => {});
+    const frame = renderPromptBanner(() => {}, { inputLineCount: 2 });
     const rendered = buildPromptInputLineWithCursor(
       frame,
       'Describe this image -> /tmp/cat.jpg',


### PR DESCRIPTION
## Summary
- align shell input prompt rendering to be compact-first and expand naturally like Codex
- fix multiline wrapping/cursor placement with attachment preview overlay rows
- add/update renderer tests to lock in Codex-style behavior
- make pre-commit backend test invocation deterministic (explicit solution + pinned dotnet binary)

## Validation
- pre-commit hook run (CLI tests + backend tests) passed during commit
- npm run test -- test/shell/renderer.test.ts
- npm run test -- test/shell
- npm run build