### PR TITLE
fix(ci): prevent duplicate Codex review comments on PR reruns

### DIFF
--- a/.github/scripts/codex-pr-review.mjs
+++ b/.github/scripts/codex-pr-review.mjs
@@ -55,6 +55,7 @@ if (!openAiKey) {
 const githubApi = process.env.GITHUB_API_URL || 'https://api.github.com';
 const model = process.env.CODEX_REVIEW_MODEL || 'gpt-5.2';
 const maxDiffChars = Number.parseInt(process.env.CODEX_REVIEW_DIFF_MAX || '120000', 10);
+const codexReviewMarker = '<!-- codex-review -->';
 
 async function githubRequest(path, options = {}) {
   const response = await fetch(`${githubApi}${path}`, {
@@ -72,6 +73,23 @@ async function githubRequest(path, options = {}) {
   }
 
   return response;
+}
+
+const existingReviewsResponse = await githubRequest(
+  `/repos/${owner}/${repo}/pulls/${pr.number}/reviews?per_page=100`,
+  {
+    headers: {
+      Accept: 'application/vnd.github+json',
+    },
+  }
+);
+const existingReviews = await existingReviewsResponse.json();
+const alreadyReviewed = Array.isArray(existingReviews)
+  && existingReviews.some((review) => typeof review?.body === 'string' && review.body.includes(codexReviewMarker));
+
+if (alreadyReviewed) {
+  console.log('Existing Codex review found for this PR; skipping duplicate review comment.');
+  process.exit(0);
 }
 
 const diffResponse = await githubRequest(`/repos/${owner}/${repo}/pulls/${pr.number}`,
@@ -120,7 +138,7 @@ if (!reviewBody) {
   throw new Error('OpenAI response did not include a review body.');
 }
 
-const taggedBody = `<!-- codex-review -->\n${reviewBody}`;
+const taggedBody = `${codexReviewMarker}\n${reviewBody}`;
 
 await githubRequest(`/repos/${owner}/${repo}/pulls/${pr.number}/reviews`, {
   method: 'POST',


### PR DESCRIPTION
## Summary
- update `.github/scripts/codex-pr-review.mjs` to detect an existing Codex review marker before generating/posting a review
- skip with exit `0` when a prior `<!-- codex-review -->` review already exists on the PR
- keep required `Codex Review` check green while avoiding duplicate review comments on every re-run/synchronize event

## Why
`Codex PR Review` runs on `pull_request_target` and currently posts a new review every trigger (`opened`, `synchronize`, `reopened`, `ready_for_review`), which creates repeated duplicate comments.

## Validation
- `node --check .github/scripts/codex-pr-review.mjs`
- `actionlint .github/workflows/codex-pr-review.yaml`

## Follow-up
After this PR merges, rerunning checks on PR #342 should no longer add extra Codex review comments.