### PR TITLE
fix(ci): authenticate update-badges default push path

### DIFF
--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -18,6 +18,7 @@ jobs:
     env:
       REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
       HAS_REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN != '' }}
+      WORKFLOW_GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout repository
@@ -151,6 +152,7 @@ jobs:
             echo "No badge changes to commit."
           else
             git commit -m "chore: update test & coverage badges [skip ci]"
+            git remote set-url origin "https://x-access-token:${WORKFLOW_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
             if git push origin HEAD:main; then
               echo "Pushed badge update via default workflow token."
               exit 0
@@ -164,8 +166,10 @@ jobs:
                 echo "Pushed badge update via REPO_ADMIN_TOKEN."
                 exit 0
               fi
+
+              echo "::error::REPO_ADMIN_TOKEN push was denied. Verify token scopes/repo access and branch bypass permissions."
             fi
 
-            echo "::error::Failed to push badge update to main. Ensure ruleset bypass includes GitHub Actions (integration id 15368) and/or the repository role of REPO_ADMIN_TOKEN."
+            echo "::error::Failed to push badge update to main. Ensure GitHub Actions bypass is configured and REPO_ADMIN_TOKEN (if used) is valid."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- ensure default `Update Badges` push is authenticated by setting origin to use `${{ github.token }}` before first `git push`
- keep PAT fallback as secondary path
- improve fallback error message to clearly call out invalid/under-scoped `REPO_ADMIN_TOKEN`

## Why
Current failure shows two issues:
1. Default push fails with `could not read Username for 'https://github.com'` (unauthenticated remote URL).
2. PAT fallback fails with `403 Permission denied` (token rejected or under-scoped).

This patch fixes (1) directly and makes (2) explicit.

## Validation
- `actionlint .github/workflows/update-badges.yaml`
- local pre-commit hooks passed (CLI + backend tests)
