### PR TITLE
feat(cli): Codex-style prompt zone, interactive update prompt, and release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cli/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'cli/**'
+
+jobs:
+  test:
+    name: Test CLI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: cli
+
+      - name: Build
+        run: npm run build
+        working-directory: cli
+
+      - name: Run tests
+        run: npm test
+        working-directory: cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write       # create GitHub Releases and tags
+      pull-requests: write  # open/update the "Version Packages" PR
+      id-token: write       # npm provenance attestation
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history is required so changesets can diff against the base branch
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install root dependencies (provides @changesets/cli)
+        run: npm install
+        working-directory: .
+
+      - name: Install CLI dependencies
+        run: npm ci
+        working-directory: cli
+
+      - name: Create Release PR or Publish to npm
+        uses: changesets/action@v1
+        with:
+          # Run changeset commands from inside the cli/ directory where
+          # .changeset/config.json lives.
+          cwd: cli
+          # Command run when the "Version Packages" PR is merged:
+          # builds the package and publishes to npm (tests already passed in CI).
+          publish: npm run ci:publish
+          # Customise the version PR title and commit message.
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+          # Automatically create a GitHub Release for each published package.
+          createGithubReleases: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/.changeset/ci-publish-script.md
+++ b/cli/.changeset/ci-publish-script.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Add ci:publish script for use in GitHub Actions release workflow (build then publish, without re-running tests).

--- a/cli/.changeset/interactive-update-prompt.md
+++ b/cli/.changeset/interactive-update-prompt.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": minor
+---
+
+Show a Codex-style interactive update notification at shell startup: arrow-key/number-key menu with "Update now", "Skip", and "Skip until next version" options; release notes link to GitHub Releases.

--- a/cli/.changeset/prompt-zone-grow-downward-no-jump.md
+++ b/cli/.changeset/prompt-zone-grow-downward-no-jump.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Grow prompt zone by appending rows at the bottom; viewport no longer jumps to the top when typing long input.

--- a/cli/.changeset/prompt-zone-max-height-spacing.md
+++ b/cli/.changeset/prompt-zone-max-height-spacing.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Cap prompt zone at 8 rows to prevent terminal scrolling; always preserve top and bottom spacing rows.

--- a/cli/.changeset/prompt-zone-single-line-height.md
+++ b/cli/.changeset/prompt-zone-single-line-height.md
@@ -2,4 +2,4 @@
 "@agon_agents/cli": patch
 ---
 
-Set initial prompt zone to 3 rows with cursor centered (promptLineOffset=1) and preserve one empty trailing row as zone grows, matching Codex layout.
+Set initial prompt zone to 3 rows with cursor centered; zone grows downward (Codex-style) preserving one empty trailing row.

--- a/cli/.changeset/prompt-zone-single-line-height.md
+++ b/cli/.changeset/prompt-zone-single-line-height.md
@@ -2,4 +2,4 @@
 "@agon_agents/cli": patch
 ---
 
-Set initial prompt zone height to 2 rows to match Codex, preserving spacing above the zone and auto-expand behaviour.
+Set initial prompt zone to 3 rows with cursor centered (promptLineOffset=1), matching Codex height and preserving spacing and auto-expand behaviour.

--- a/cli/.changeset/prompt-zone-single-line-height.md
+++ b/cli/.changeset/prompt-zone-single-line-height.md
@@ -2,4 +2,4 @@
 "@agon_agents/cli": patch
 ---
 
-Remove blank line above prompt banner so the initial input zone is one row tall, matching Codex.
+Remove blank lines above prompt banner so the initial input zone is one row tall, matching Codex.

--- a/cli/.changeset/prompt-zone-single-line-height.md
+++ b/cli/.changeset/prompt-zone-single-line-height.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Remove blank line above prompt banner so the initial input zone is one row tall, matching Codex.

--- a/cli/.changeset/prompt-zone-single-line-height.md
+++ b/cli/.changeset/prompt-zone-single-line-height.md
@@ -2,4 +2,4 @@
 "@agon_agents/cli": patch
 ---
 
-Remove blank lines above prompt banner so the initial input zone is one row tall, matching Codex.
+Set initial prompt zone height to 2 rows to match Codex, preserving spacing above the zone and auto-expand behaviour.

--- a/cli/.changeset/prompt-zone-single-line-height.md
+++ b/cli/.changeset/prompt-zone-single-line-height.md
@@ -2,4 +2,4 @@
 "@agon_agents/cli": patch
 ---
 
-Set initial prompt zone to 3 rows with cursor centered (promptLineOffset=1), matching Codex height and preserving spacing and auto-expand behaviour.
+Set initial prompt zone to 3 rows with cursor centered (promptLineOffset=1) and preserve one empty trailing row as zone grows, matching Codex layout.

--- a/cli/package.json
+++ b/cli/package.json
@@ -46,6 +46,7 @@
     "pack:dry-run": "npm pack --dry-run",
     "release:check": "npm run test && npm run pack:dry-run",
     "release:publish": "npm run release:check && npm publish",
+    "ci:publish": "npm run build && npm publish",
     "postpack": "rm -f ./README.md",
     "prepare": "npm run build"
   },

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -561,30 +561,62 @@ export default class Shell extends Command {
         if (nextInputLineCount === currentFrame.inputLineCount) {
           return;
         }
-        // Move to zone row 0 (not above it) so new rows are appended at the
-        // bottom.  If the zone is at the terminal viewport bottom the terminal
-        // scrolls naturally, pushing old content up — matching Codex behaviour.
-        const moveUpLines = cursorLineIndex;
-        if (moveUpLines > 0) {
-          output.write(`\u001b[${moveUpLines}A\r`);
+
+        if (nextInputLineCount > currentFrame.inputLineCount) {
+          // Growing: append rows at the bottom so the viewport never jumps.
+          // Move down to the last row of the current zone.
+          const linesToBottom = currentFrame.inputLineCount - 1 - cursorLineIndex;
+          if (linesToBottom > 0) {
+            output.write(`\u001b[${linesToBottom}B`);
+          }
+          // Append new highlighted padding rows below the current zone.
+          // Each \r\n advances one line (scrolling the terminal if at viewport
+          // bottom, which pushes old content up — matching Codex behaviour).
+          const paddingLine = `${currentFrame.backgroundStart}${' '.repeat(currentFrame.width)}${currentFrame.reset}`;
+          const rowsToAdd = nextInputLineCount - currentFrame.inputLineCount;
+          for (let i = 0; i < rowsToAdd; i++) {
+            output.write(`\r\n${paddingLine}`);
+          }
+          // Cursor is now on the last row of the new zone (row nextInputLineCount - 1).
+          // Update frame dimensions; all other properties are unchanged.
+          currentFrame = {
+            ...currentFrame,
+            inputLineCount: nextInputLineCount,
+            cursorUpLines: nextInputLineCount,
+            cursorDownFromFirstLine: nextInputLineCount
+          };
+          const newCursorLineIndex = getPromptCursorPosition(currentFrame, value, cursorIndex).lineIndex;
+          // Move up from the last row to newCursorLineIndex so redraw() can proceed.
+          const moveUpToContent = nextInputLineCount - 1 - newCursorLineIndex;
+          if (moveUpToContent > 0) {
+            output.write(`\u001b[${moveUpToContent}A\r`);
+          } else {
+            output.write('\r');
+          }
+          cursorLineIndex = newCursorLineIndex;
         } else {
-          output.write('\r');
+          // Shrinking: clear from zone top and re-render (no viewport jump risk
+          // since the zone is getting smaller, not larger).
+          const moveUpLines = cursorLineIndex;
+          if (moveUpLines > 0) {
+            output.write(`\u001b[${moveUpLines}A\r`);
+          } else {
+            output.write('\r');
+          }
+          output.write('\u001b[0J');
+          currentFrame = renderPromptBanner(
+            (line) => output.write(`${line}\n`),
+            { inputLineCount: nextInputLineCount }
+          );
+          const newCursorLineIndex = getPromptCursorPosition(currentFrame, value, cursorIndex).lineIndex;
+          const upToNewCursorLine = currentFrame.cursorUpLines - newCursorLineIndex;
+          if (upToNewCursorLine > 0) {
+            output.write(`\u001b[${upToNewCursorLine}A\r`);
+          } else {
+            output.write('\r');
+          }
+          cursorLineIndex = newCursorLineIndex;
         }
-        output.write('\u001b[0J');
-        currentFrame = renderPromptBanner(
-          (line) => output.write(`${line}\n`),
-          { inputLineCount: nextInputLineCount }
-        );
-        // Position cursor at newCursorLineIndex within the new frame.
-        // redraw() will then move up newCursorLineIndex lines to reach row 0.
-        const newCursorLineIndex = getPromptCursorPosition(currentFrame, value, cursorIndex).lineIndex;
-        const upToNewCursorLine = currentFrame.cursorUpLines - newCursorLineIndex;
-        if (upToNewCursorLine > 0) {
-          output.write(`\u001b[${upToNewCursorLine}A\r`);
-        } else {
-          output.write('\r');
-        }
-        cursorLineIndex = newCursorLineIndex;
       };
 
       const redraw = (): void => {

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -41,8 +41,11 @@ import { AgonError, ErrorCode } from '../utils/error-handler.js';
 import {
   describeSelfUpdateFailure,
   getSelfUpdateGuidance,
+  getSelfUpdateRestartNotice,
   runNpmGlobalInstall
 } from '../utils/self-update.js';
+import { showUpdatePrompt } from '../utils/update-prompt.js';
+import { getUpdateSkipVersion, setUpdateSkipVersion } from '../utils/update-skip-state.js';
 import { buildRuntimeExecutionProfile } from '../runtime/user-runtime-profile.js';
 import { AGENT_MODEL_IDS } from '../state/agent-model-config.js';
 
@@ -252,17 +255,29 @@ export default class Shell extends Command {
       (line) => this.log(line)
     );
     renderStatusLine((line) => this.log(line));
-    const updateInfo = await checkForCliUpdate({
-      packageName: this.config.pjson.name ?? '@agon_agents/cli',
-      currentVersion: this.config.pjson.version ?? '0.0.0'
-    });
+    const packageName = this.config.pjson.name ?? '@agon_agents/cli';
+    const currentVersion = this.config.pjson.version ?? '0.0.0';
+    const updateInfo = await checkForCliUpdate({ packageName, currentVersion });
     if (updateInfo) {
-      this.log(chalk.yellow(`Update available: v${updateInfo.currentVersion} → v${updateInfo.latestVersion}`));
-      this.log(chalk.cyan('Run now in this shell:'));
-      this.log(chalk.cyan('  /update'));
-      this.log(chalk.dim('Tip: Use /update --check to only verify availability.'));
-      this.log(chalk.dim('If that fails, run:'));
-      this.log(chalk.dim(`  ${updateInfo.installCommand}`));
+      const skipVersion = await getUpdateSkipVersion();
+      if (skipVersion !== updateInfo.latestVersion) {
+        const choice = await showUpdatePrompt(updateInfo);
+        if (choice === 'skip-version') {
+          await setUpdateSkipVersion(updateInfo.latestVersion);
+        } else if (choice === 'update') {
+          const updateSpinner = ora({ text: `Installing ${packageName}@latest...`, color: 'cyan' }).start();
+          try {
+            await runNpmGlobalInstall(packageName);
+            updateSpinner.succeed(`Updated to v${updateInfo.latestVersion}.`);
+            this.log(chalk.yellow(getSelfUpdateRestartNotice(updateInfo.latestVersion)));
+          } catch (updateError) {
+            updateSpinner.fail('Update failed.');
+            const failure = describeSelfUpdateFailure(updateError);
+            this.log(chalk.red(failure.message));
+            this.log(chalk.dim(getSelfUpdateGuidance(failure.category, updateInfo.installCommand)));
+          }
+        }
+      }
     }
     this.log('');
 

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -591,7 +591,7 @@ export default class Shell extends Command {
         const requiredLines = getWrappedLineCount(preview.displayValue, currentFrame.maxInputCharsPerLine);
         const desiredInputLineCount = Math.min(
           maxInputLineCount,
-          Math.max(minInputLineCount, currentFrame.promptLineOffset + requiredLines)
+          Math.max(minInputLineCount, currentFrame.promptLineOffset + requiredLines + 1)
         );
         if (desiredInputLineCount !== currentFrame.inputLineCount) {
           resizePromptFrame(desiredInputLineCount);

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -268,7 +268,6 @@ export default class Shell extends Command {
 
     try {
       while (true) {
-        this.log('');
         const promptFrame = renderPromptBanner((line) => this.log(line));
         const activeSession = await controller.getActiveSession();
         const rawInput = await this.promptForInput(promptFrame, activeSession?.id ?? null);

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -561,7 +561,10 @@ export default class Shell extends Command {
         if (nextInputLineCount === currentFrame.inputLineCount) {
           return;
         }
-        const moveUpLines = cursorLineIndex + 1;
+        // Move to zone row 0 (not above it) so new rows are appended at the
+        // bottom.  If the zone is at the terminal viewport bottom the terminal
+        // scrolls naturally, pushing old content up — matching Codex behaviour.
+        const moveUpLines = cursorLineIndex;
         if (moveUpLines > 0) {
           output.write(`\u001b[${moveUpLines}A\r`);
         } else {
@@ -572,10 +575,8 @@ export default class Shell extends Command {
           (line) => output.write(`${line}\n`),
           { inputLineCount: nextInputLineCount }
         );
-        // Position cursor at the logical cursor row within the new frame, not at
-        // row 0. redraw() moves up cursorLineIndex lines to reach row 0 before
-        // writing content — if we land at row 0 here, that move goes above the
-        // frame and overwrites the output above it.
+        // Position cursor at newCursorLineIndex within the new frame.
+        // redraw() will then move up newCursorLineIndex lines to reach row 0.
         const newCursorLineIndex = getPromptCursorPosition(currentFrame, value, cursorIndex).lineIndex;
         const upToNewCursorLine = currentFrame.cursorUpLines - newCursorLineIndex;
         if (upToNewCursorLine > 0) {

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -264,7 +264,6 @@ export default class Shell extends Command {
       this.log(chalk.dim('If that fails, run:'));
       this.log(chalk.dim(`  ${updateInfo.installCommand}`));
     }
-    this.log('');
 
     try {
       while (true) {

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -542,9 +542,11 @@ export default class Shell extends Command {
 
     let currentFrame = frame;
     const minInputLineCount = frame.inputLineCount;
+    // Cap the zone at ~8 rows so it never grows large enough to scroll the
+    // terminal and reveal old shell history above the Agon UI.
     const maxInputLineCount = Math.max(
       minInputLineCount,
-      Math.min((output.rows ?? 24) - 8, 18)
+      Math.min((output.rows ?? 24) - 16, 8)
     );
 
     output.write(`\u001b[${currentFrame.cursorUpLines}A\r`);
@@ -622,9 +624,13 @@ export default class Shell extends Command {
       const redraw = (): void => {
         const preview = this.buildLiveAttachmentPreview(value, cursorIndex, activeSessionId);
         const requiredLines = getWrappedLineCount(preview.displayValue, currentFrame.maxInputCharsPerLine);
+        // Always reserve one empty row at the bottom (beyond promptLineOffset at
+        // top), so spacing is preserved even when the zone is at maxInputLineCount.
+        const maxEditableRows = Math.max(1, maxInputLineCount - currentFrame.promptLineOffset - 1);
+        const clampedRequiredLines = Math.min(requiredLines, maxEditableRows);
         const desiredInputLineCount = Math.min(
           maxInputLineCount,
-          Math.max(minInputLineCount, currentFrame.promptLineOffset + requiredLines + 1)
+          Math.max(minInputLineCount, currentFrame.promptLineOffset + clampedRequiredLines + 1)
         );
         if (desiredInputLineCount !== currentFrame.inputLineCount) {
           resizePromptFrame(desiredInputLineCount);

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -264,9 +264,11 @@ export default class Shell extends Command {
       this.log(chalk.dim('If that fails, run:'));
       this.log(chalk.dim(`  ${updateInfo.installCommand}`));
     }
+    this.log('');
 
     try {
       while (true) {
+        this.log('');
         const promptFrame = renderPromptBanner((line) => this.log(line));
         const activeSession = await controller.getActiveSession();
         const rawInput = await this.promptForInput(promptFrame, activeSession?.id ?? null);

--- a/cli/src/shell/renderer.ts
+++ b/cli/src/shell/renderer.ts
@@ -313,9 +313,11 @@ function createPromptFrame(inputLineCountOverride?: number): PromptFrame {
   const terminalWidth = process.stdout.columns ?? 100;
   // Codex-like wide prompt zone: keep a small side margin, but avoid runaway ultra-wide lines.
   const width = Math.max(72, Math.min(terminalWidth - 4, 180));
-  // Start as a two-row zone (matching Codex) and let the frame grow with input.
-  const inputLineCount = Math.max(1, inputLineCountOverride ?? 2);
-  const promptLineOffset = 0;
+  // Start as a three-row zone: one empty row above the cursor, the cursor row,
+  // and one empty row below — giving a centered, Codex-height initial state.
+  // promptLineOffset=1 keeps the cursor on the second row as the zone grows.
+  const inputLineCount = Math.max(2, inputLineCountOverride ?? 3);
+  const promptLineOffset = 1;
   const borderLine = chalk.whiteBright('─'.repeat(width));
   const backgroundStart = '\u001b[48;2;63;111;201m';
   const promptStart = `${backgroundStart}\u001b[97m`;

--- a/cli/src/shell/renderer.ts
+++ b/cli/src/shell/renderer.ts
@@ -313,8 +313,8 @@ function createPromptFrame(inputLineCountOverride?: number): PromptFrame {
   const terminalWidth = process.stdout.columns ?? 100;
   // Codex-like wide prompt zone: keep a small side margin, but avoid runaway ultra-wide lines.
   const width = Math.max(72, Math.min(terminalWidth - 4, 180));
-  // Start as a single prompt row and let the frame grow with input.
-  const inputLineCount = Math.max(1, inputLineCountOverride ?? 1);
+  // Start as a two-row zone (matching Codex) and let the frame grow with input.
+  const inputLineCount = Math.max(1, inputLineCountOverride ?? 2);
   const promptLineOffset = 0;
   const borderLine = chalk.whiteBright('─'.repeat(width));
   const backgroundStart = '\u001b[48;2;63;111;201m';

--- a/cli/src/utils/update-prompt.ts
+++ b/cli/src/utils/update-prompt.ts
@@ -1,0 +1,147 @@
+import { emitKeypressEvents } from 'node:readline';
+import chalk from 'chalk';
+import { formatTerminalLink } from './terminal-links.js';
+import type { CliUpdateInfo } from './update-check.js';
+
+export type UpdatePromptChoice = 'update' | 'skip' | 'skip-version';
+
+export const RELEASES_URL = 'https://github.com/simonholmes001/agon/releases/latest';
+
+interface MenuItem {
+  label: (installCommand: string) => string;
+  choice: UpdatePromptChoice;
+}
+
+const MENU: MenuItem[] = [
+  { label: (cmd) => `Update now (runs \`${cmd}\`)`, choice: 'update' },
+  { label: () => 'Skip', choice: 'skip' },
+  { label: () => 'Skip until next version', choice: 'skip-version' }
+];
+
+/** Number of output lines the menu occupies (items + blank + hint). */
+const MENU_LINE_COUNT = MENU.length + 2;
+
+/**
+ * Display a Codex-style update notification with an interactive arrow-key /
+ * number-key menu.  Falls back to a plain text notice if stdin is not a TTY.
+ */
+export async function showUpdatePrompt(updateInfo: CliUpdateInfo): Promise<UpdatePromptChoice> {
+  const out = process.stdout;
+
+  const releaseNotesLink = formatTerminalLink(RELEASES_URL, RELEASES_URL);
+
+  out.write('\n');
+  out.write(
+    `${chalk.yellow('✨')} ${chalk.bold('Update available!')} ` +
+    `${chalk.dim(updateInfo.currentVersion)} ${chalk.dim('→')} ${chalk.bold(updateInfo.latestVersion)}\n`
+  );
+  out.write(`${chalk.dim('Release notes:')} ${chalk.cyan(releaseNotesLink)}\n`);
+  out.write('\n');
+
+  // Non-interactive fallback (piped / non-TTY stdout or stdin).
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    renderMenuStatic(out, updateInfo.installCommand, 0);
+    return 'skip';
+  }
+
+  return runInteractiveMenu(updateInfo.installCommand);
+}
+
+function renderMenuStatic(
+  out: NodeJS.WriteStream,
+  installCommand: string,
+  selectedIndex: number
+): void {
+  for (let i = 0; i < MENU.length; i++) {
+    const label = MENU[i].label(installCommand);
+    if (i === selectedIndex) {
+      out.write(`${chalk.green('> ')}${chalk.green(`${i + 1}. ${label}`)}\n`);
+    } else {
+      out.write(`  ${i + 1}. ${label}\n`);
+    }
+  }
+  out.write('\n');
+  out.write(chalk.dim('Press enter to continue\n'));
+}
+
+function clearMenu(out: NodeJS.WriteStream): void {
+  out.write(`\u001b[${MENU_LINE_COUNT}A`); // move up
+  out.write('\u001b[0J');                   // clear to end of screen
+}
+
+function runInteractiveMenu(installCommand: string): Promise<UpdatePromptChoice> {
+  const inp = process.stdin;
+  const out = process.stdout;
+
+  return new Promise<UpdatePromptChoice>((resolve) => {
+    let selectedIndex = 0;
+
+    const render = (): void => renderMenuStatic(out, installCommand, selectedIndex);
+
+    const finish = (choice: UpdatePromptChoice): void => {
+      inp.setRawMode(false);
+      inp.removeListener('keypress', onKeypress);
+      inp.pause();
+      resolve(choice);
+    };
+
+    const onKeypress = (_str: string | undefined, key?: { name?: string; sequence?: string; ctrl?: boolean }): void => {
+      if (!key) {
+        return;
+      }
+
+      // Ctrl+C — bail out as "skip"
+      if (key.ctrl && key.name === 'c') {
+        finish('skip');
+        return;
+      }
+
+      if (key.name === 'up') {
+        if (selectedIndex > 0) {
+          clearMenu(out);
+          selectedIndex--;
+          render();
+        }
+        return;
+      }
+
+      if (key.name === 'down') {
+        if (selectedIndex < MENU.length - 1) {
+          clearMenu(out);
+          selectedIndex++;
+          render();
+        }
+        return;
+      }
+
+      // Number keys 1–N for direct selection + immediate confirm
+      const digit = key.sequence ? Number(key.sequence) : NaN;
+      if (!isNaN(digit) && digit >= 1 && digit <= MENU.length) {
+        clearMenu(out);
+        selectedIndex = digit - 1;
+        render();
+        finish(MENU[selectedIndex].choice);
+        return;
+      }
+
+      // Enter confirms current selection
+      if (key.name === 'return' || key.name === 'enter') {
+        finish(MENU[selectedIndex].choice);
+        return;
+      }
+
+      // Escape / q — treat as skip
+      if (key.name === 'escape' || key.name === 'q') {
+        finish('skip');
+        return;
+      }
+    };
+
+    render();
+
+    emitKeypressEvents(inp);
+    inp.setRawMode(true);
+    inp.resume();
+    inp.on('keypress', onKeypress);
+  });
+}

--- a/cli/src/utils/update-skip-state.ts
+++ b/cli/src/utils/update-skip-state.ts
@@ -1,0 +1,30 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+const SKIP_STATE_FILE = path.join(os.homedir(), '.agon_update_skip');
+
+/**
+ * Returns the version the user last chose to "skip until next version", or
+ * null if no skip is recorded or the file cannot be read.
+ */
+export async function getUpdateSkipVersion(): Promise<string | null> {
+  try {
+    const content = await fs.readFile(SKIP_STATE_FILE, 'utf-8');
+    return content.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the given version as the "skip until next version" marker.
+ * Best-effort: errors are silently ignored.
+ */
+export async function setUpdateSkipVersion(version: string): Promise<void> {
+  try {
+    await fs.writeFile(SKIP_STATE_FILE, version.trim(), 'utf-8');
+  } catch {
+    // Best-effort
+  }
+}

--- a/cli/test/shell/renderer.test.ts
+++ b/cli/test/shell/renderer.test.ts
@@ -104,13 +104,13 @@ describe('shell renderer', () => {
     expect(frame.maxInputChars).toBeGreaterThan(0);
     expect(frame.cursorUpLines).toBe(frame.inputLineCount);
     expect(frame.cursorDownFromFirstLine).toBe(frame.inputLineCount);
-    expect(frame.inputLineCount).toBe(2);
-    expect(frame.promptLineOffset).toBe(0);
+    expect(frame.inputLineCount).toBe(3);
+    expect(frame.promptLineOffset).toBe(1);
   });
 
-  it('starts prompt on the first input row (Codex-like compact input zone)', () => {
+  it('starts prompt on the second input row (centered in three-row zone)', () => {
     const frame = renderPromptBanner(() => {});
-    expect(frame.promptLineOffset).toBe(0);
+    expect(frame.promptLineOffset).toBe(1);
   });
 
   it('builds an active prompt line with an input cursor prefix', () => {
@@ -120,7 +120,7 @@ describe('shell renderer', () => {
     const rows = plain.split('\n');
 
     expect(prompt).toContain('\u001b[48;2;63;111;201m');
-    expect(rows[0]).toContain('  > ');
+    expect(rows[1]).toContain('  > ');
   });
 
   it('builds shimmer text variants while preserving visible message', () => {
@@ -158,7 +158,7 @@ describe('shell renderer', () => {
     const rendered = buildPromptInputLine(frame, longValue);
 
     expect(rendered).toContain('\n');
-    expect(getPromptCursorPosition(frame, longValue, longValue.length).lineIndex).toBe(1);
+    expect(getPromptCursorPosition(frame, longValue, longValue.length).lineIndex).toBe(2);
   });
 
   it('wraps on word boundaries when space is available', () => {
@@ -170,7 +170,7 @@ describe('shell renderer', () => {
     const rows = plain.split('\n');
 
     expect(rows[0]).not.toContain('alph');
-    expect(rows[1]).toContain('alpha beta');
+    expect(rows[2]).toContain('alpha beta');
   });
 
   it('preserves explicit newline boundaries in prompt rendering', () => {

--- a/cli/test/shell/renderer.test.ts
+++ b/cli/test/shell/renderer.test.ts
@@ -104,7 +104,7 @@ describe('shell renderer', () => {
     expect(frame.maxInputChars).toBeGreaterThan(0);
     expect(frame.cursorUpLines).toBe(frame.inputLineCount);
     expect(frame.cursorDownFromFirstLine).toBe(frame.inputLineCount);
-    expect(frame.inputLineCount).toBe(1);
+    expect(frame.inputLineCount).toBe(2);
     expect(frame.promptLineOffset).toBe(0);
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.0.0",
       "workspaces": [
         "cli"
-      ]
+      ],
+      "devDependencies": {
+        "@changesets/cli": "^2.27.12"
+      }
     },
     "cli": {
       "name": "@agon_agents/cli",
-      "version": "0.8.9",
+      "version": "0.8.11",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^3.0.0",
@@ -1578,6 +1581,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -1600,6 +1613,420 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz",
+      "integrity": "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/config": "^3.1.3",
+        "@changesets/get-version-range-type": "^0.4.0",
+        "@changesets/git": "^3.0.4",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "detect-indent": "^6.0.0",
+        "fs-extra": "^7.0.1",
+        "lodash.startcase": "^4.4.0",
+        "outdent": "^0.5.0",
+        "prettier": "^2.7.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/detect-indent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@changesets/apply-release-plan/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/assemble-release-plan": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
+      "integrity": "sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/changelog-git": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
+      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0"
+      }
+    },
+    "node_modules/@changesets/cli": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.30.0.tgz",
+      "integrity": "sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^7.1.0",
+        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/changelog-git": "^0.2.1",
+        "@changesets/config": "^3.1.3",
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/get-release-plan": "^4.0.15",
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@changesets/write": "^0.4.0",
+        "@inquirer/external-editor": "^1.0.2",
+        "@manypkg/get-packages": "^1.1.3",
+        "ansi-colors": "^4.1.3",
+        "enquirer": "^2.4.1",
+        "fs-extra": "^7.0.1",
+        "mri": "^1.2.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "spawndamnit": "^3.0.1",
+        "term-size": "^2.1.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.3.tgz",
+      "integrity": "sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/get-dependents-graph": "^2.1.3",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/should-skip-package": "^0.1.2",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1",
+        "micromatch": "^4.0.8"
+      }
+    },
+    "node_modules/@changesets/config/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
+      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extendable-error": "^0.1.5"
+      }
+    },
+    "node_modules/@changesets/get-dependents-graph": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.3.tgz",
+      "integrity": "sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "picocolors": "^1.1.0",
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/@changesets/get-release-plan": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.15.tgz",
+      "integrity": "sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/assemble-release-plan": "^6.0.9",
+        "@changesets/config": "^3.1.3",
+        "@changesets/pre": "^2.0.2",
+        "@changesets/read": "^0.6.7",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/get-version-range-type": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
+      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/git": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
+      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
+      }
+    },
+    "node_modules/@changesets/logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/parse": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "js-yaml": "^4.1.1"
+      }
+    },
+    "node_modules/@changesets/parse/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@changesets/parse/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@changesets/pre": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
+      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/errors": "^0.2.0",
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3",
+        "fs-extra": "^7.0.1"
+      }
+    },
+    "node_modules/@changesets/pre/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/read": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/git": "^3.0.4",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/parse": "^0.4.3",
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
+      }
+    },
+    "node_modules/@changesets/read/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/should-skip-package": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
+      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "@manypkg/get-packages": "^1.1.3"
+      }
+    },
+    "node_modules/@changesets/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@changesets/write": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
+      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/types": "^6.1.0",
+        "fs-extra": "^7.0.1",
+        "human-id": "^4.1.1",
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@colors/colors": {
@@ -2967,6 +3394,104 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@manypkg/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@types/node": "^12.7.1",
+        "find-up": "^4.1.0",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@manypkg/find-root/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@manypkg/find-root/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
+      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@changesets/types": "^4.0.1",
+        "@manypkg/find-root": "^1.1.0",
+        "fs-extra": "^8.1.0",
+        "globby": "^11.0.0",
+        "read-yaml-file": "^1.1.0"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
@@ -5089,6 +5614,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5246,6 +5781,19 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/better-path-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
+      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-windows": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -5847,6 +6395,20 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -6231,6 +6793,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extendable-error": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
+      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6876,6 +7445,16 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/human-id": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
+      "integrity": "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
     "node_modules/hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
@@ -7427,6 +8006,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-subdir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
+      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "better-path-resolve": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -7437,6 +8029,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-wsl": {
@@ -7917,6 +8519,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
@@ -8100,6 +8709,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -8483,6 +9102,13 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/outdent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
+      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-cancelable": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
@@ -8491,6 +9117,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -8523,6 +9162,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
+      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quansync": "^0.2.7"
       }
     },
     "node_modules/param-case": {
@@ -8676,6 +9345,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -8757,6 +9436,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8788,6 +9484,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-yaml-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
+      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.5",
+        "js-yaml": "^3.6.1",
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/redeyed": {
@@ -9139,6 +9851,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spawndamnit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
+      }
+    },
+    "node_modules/spawndamnit/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -9272,6 +10008,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
@@ -9332,6 +10078,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/term-size": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "workspaces": [
     "cli"
   ],
+  "devDependencies": {
+    "@changesets/cli": "^2.27.12"
+  },
   "overrides": {
     "fast-xml-parser": "^5.5.6"
   }


### PR DESCRIPTION
## Summary

- **Prompt zone redesigned to match Codex** — 3-row initial zone with cursor centered; zone grows downward (appending rows at the bottom) without jumping the viewport; capped at 8 rows so the terminal never scrolls into old shell history; top and bottom spacing rows always preserved
- **Interactive update notification** — replaces the plain-text update notice with a Codex-style menu at startup: arrow-key/number-key selection between "Update now", "Skip", and "Skip until next version"; release notes link points to GitHub Releases
- **GitHub Actions CI + release automation** — `ci.yml` runs build and tests on every push/PR touching `cli/`; `release.yml` uses the changesets action to open a "Version Packages" PR when changesets are pending, then publishes to npm and creates a GitHub Release when that PR merges

## Changesets

Six changeset files are included — the `interactive-update-prompt` changeset is `minor`, the rest are `patch`, so merging will produce a `0.9.0` release.

## Test plan

- [ ] All 614 CLI tests pass (`npm test` in `cli/`)
- [ ] All backend tests pass
- [ ] Start shell with a lower current version or mock `checkForCliUpdate` to verify the interactive update menu appears, arrow keys and number keys work, and "Skip until next version" suppresses the prompt on next launch
- [ ] Verify prompt zone starts with 1 empty row above and below the cursor row
- [ ] Type a long input — zone grows downward (no viewport jump), text scrolls within the zone after 6 lines
- [ ] Confirm `NPM_TOKEN` secret is set in repo settings before merging (required for the release workflow to publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)