### PR TITLE
fix(cli): recover from long-running invoke-council request timeouts

### DIFF
--- a/cli/.changeset/fix-council-followup-timeout.md
+++ b/cli/.changeset/fix-council-followup-timeout.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Prevent false failures for long-running `invoke council` follow-ups by increasing the message submission timeout and recovering from client-side timeouts by polling session/messages for the eventual response.

--- a/cli/.changeset/fix-timeout-signal-hardening.md
+++ b/cli/.changeset/fix-timeout-signal-hardening.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Harden long-running follow-up handling with structured timeout classification, configurable follow-up request timeout (`AGON_FOLLOWUP_TIMEOUT_MS`), and robust timeout-recovery state persistence.

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -38,6 +38,7 @@ export interface AuthStatusResponse {
 export class AgonAPIClient {
   private readonly client: AxiosInstance;
   private readonly maxRetries = 2;
+  private readonly followUpTimeoutMs = 300000;
   private readonly logger: Logger;
   private readonly packageName: string;
   private readonly cliVersion: string;
@@ -242,7 +243,7 @@ export class AgonAPIClient {
       `/sessions/${sessionId}/messages`,
       request,
       {
-        timeout: 120000, // Follow-up responses can take longer than default request timeout.
+        timeout: this.followUpTimeoutMs,
         headers: this.getExecutionRequestHeaders(),
       }
     );

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -38,7 +38,7 @@ export interface AuthStatusResponse {
 export class AgonAPIClient {
   private readonly client: AxiosInstance;
   private readonly maxRetries = 2;
-  private readonly followUpTimeoutMs = 300000;
+  private readonly followUpTimeoutMs: number;
   private readonly logger: Logger;
   private readonly packageName: string;
   private readonly cliVersion: string;
@@ -55,6 +55,7 @@ export class AgonAPIClient {
     this.packageName = packageName;
     this.cliVersion = cliVersion;
     this.runtimeProfile = runtimeProfile;
+    this.followUpTimeoutMs = resolveFollowUpTimeoutMs(process.env.AGON_FOLLOWUP_TIMEOUT_MS);
     // Resolve auth token: explicit parameter > AGON_AUTH_TOKEN env > AGON_BEARER_TOKEN env
     const resolvedAuthToken =
       authToken?.trim() ||
@@ -491,7 +492,7 @@ export class AgonAPIClient {
     // Network error
     this.logger.error('Network error', { message: error.message });
 
-    const timeoutMessage = (error.message || '').toLowerCase().includes('timeout');
+    const timeoutError = error.code === 'ECONNABORTED';
     const timeoutSuggestions = [
       'The backend may still be processing your request',
       'Run `/refresh verdict` in shell to check for new assistant output',
@@ -499,9 +500,9 @@ export class AgonAPIClient {
     ];
 
     return new AgonError(
-      ErrorCode.NETWORK_ERROR,
+      timeoutError ? ErrorCode.TIMEOUT : ErrorCode.NETWORK_ERROR,
       error.message || 'Network error',
-      timeoutMessage
+      timeoutError
         ? timeoutSuggestions
         : ['Check your internet connection', 'Verify the API URL is correct']
     );
@@ -659,6 +660,20 @@ export class AgonAPIClient {
 
     return headers;
   }
+}
+
+function resolveFollowUpTimeoutMs(rawValue: string | undefined): number {
+  const defaultTimeoutMs = 300000;
+  if (!rawValue || !rawValue.trim()) {
+    return defaultTimeoutMs;
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed < 1000) {
+    return defaultTimeoutMs;
+  }
+
+  return Math.floor(parsed);
 }
 
 function guessContentType(fileName: string): string {

--- a/cli/src/shell/controller.ts
+++ b/cli/src/shell/controller.ts
@@ -140,6 +140,9 @@ export class ShellController {
             afterCreatedAt: previousResponseTimestamp,
             previousPostDeliveryCreatedAt: previousAssistant?.createdAt
           });
+          await this.sessionManager.saveSession(recovered.session);
+          this.shellSessionId = sessionId;
+          this.awaitingNewIdea = false;
           return recovered;
         }
 
@@ -483,11 +486,11 @@ export class ShellController {
   }
 
   private isRequestTimeoutError(error: unknown): boolean {
-    if (!(error instanceof AgonError) || error.code !== ErrorCode.NETWORK_ERROR) {
+    if (!(error instanceof AgonError)) {
       return false;
     }
 
-    return error.message.toLowerCase().includes('timeout');
+    return error.code === ErrorCode.TIMEOUT;
   }
 
   private async clearStaleSessionState(sessionId: string): Promise<void> {

--- a/cli/src/shell/controller.ts
+++ b/cli/src/shell/controller.ts
@@ -131,7 +131,21 @@ export class ShellController {
       const previousAssistant = getLatestPostDeliveryAssistantMessage(beforeMessages);
       const previousResponseTimestamp = this.getLatestMessageCreatedAt(beforeMessages);
 
-      const updated = await this.apiClient.submitMessage(sessionId, content);
+      let updated: SessionResponse;
+      try {
+        updated = await this.apiClient.submitMessage(sessionId, content);
+      } catch (error) {
+        if (this.isRequestTimeoutError(error)) {
+          const recovered = await this.waitForNextResponse(sessionId, {
+            afterCreatedAt: previousResponseTimestamp,
+            previousPostDeliveryCreatedAt: previousAssistant?.createdAt
+          });
+          return recovered;
+        }
+
+        throw error;
+      }
+
       await this.sessionManager.saveSession(updated);
 
       this.shellSessionId = sessionId;
@@ -466,6 +480,14 @@ export class ShellController {
 
   private isSessionNotFoundError(error: unknown): boolean {
     return error instanceof AgonError && error.code === ErrorCode.SESSION_NOT_FOUND;
+  }
+
+  private isRequestTimeoutError(error: unknown): boolean {
+    if (!(error instanceof AgonError) || error.code !== ErrorCode.NETWORK_ERROR) {
+      return false;
+    }
+
+    return error.message.toLowerCase().includes('timeout');
   }
 
   private async clearStaleSessionState(sessionId: string): Promise<void> {

--- a/cli/src/utils/error-handler.ts
+++ b/cli/src/utils/error-handler.ts
@@ -9,6 +9,7 @@ import chalk from 'chalk';
 
 export enum ErrorCode {
   NETWORK_ERROR = 'NETWORK_ERROR',
+  TIMEOUT = 'TIMEOUT',
   API_ERROR = 'API_ERROR',
   SESSION_NOT_FOUND = 'SESSION_NOT_FOUND',
   INVALID_INPUT = 'INVALID_INPUT',
@@ -64,7 +65,7 @@ export function formatError(error: unknown): string {
  */
 export function isNetworkError(error: unknown): boolean {
   if (error instanceof AgonError) {
-    return error.code === ErrorCode.NETWORK_ERROR;
+    return error.code === ErrorCode.NETWORK_ERROR || error.code === ErrorCode.TIMEOUT;
   }
   
   if (error instanceof Error) {

--- a/cli/test/api/agon-client.test.ts
+++ b/cli/test/api/agon-client.test.ts
@@ -29,6 +29,7 @@ describe('AgonAPIClient', () => {
     vi.resetAllMocks();
     delete process.env.AGON_AUTH_TOKEN;
     delete process.env.AGON_BEARER_TOKEN;
+    delete process.env.AGON_FOLLOWUP_TIMEOUT_MS;
 
     mockAxios = {
       get: vi.fn(),
@@ -245,6 +246,17 @@ describe('AgonAPIClient', () => {
       expect(mapped).toBeInstanceOf(AgonError);
       const agonError = mapped as AgonError;
       expect(agonError.code).toBe(ErrorCode.BACKEND_UNAVAILABLE);
+    });
+
+    it('should map axios timeout errors to TIMEOUT', () => {
+      const error: any = new Error('timeout');
+      error.code = 'ECONNABORTED';
+
+      const mapped = (client as any).mapError(error);
+      expect(mapped).toBeInstanceOf(AgonError);
+      const agonError = mapped as AgonError;
+      expect(agonError.code).toBe(ErrorCode.TIMEOUT);
+      expect(agonError.suggestions).toContain('The backend may still be processing your request');
     });
 
     it('should map attachment storage-not-configured 503 to actionable backend unavailable message', () => {
@@ -555,6 +567,26 @@ describe('AgonAPIClient', () => {
       expect(result).toEqual(mockResponse);
     });
 
+    it('uses AGON_FOLLOWUP_TIMEOUT_MS when configured', async () => {
+      process.env.AGON_FOLLOWUP_TIMEOUT_MS = '180000';
+      const envClient = new AgonAPIClient('http://localhost:5000', '@agon_agents/cli', '0.1.3');
+      const sessionId = 'test-session-123';
+      const content = 'Follow-up';
+
+      (mockAxios.post as any).mockResolvedValue({ data: baseResponse(sessionId) });
+
+      await envClient.submitMessage(sessionId, content);
+
+      expect(mockAxios.post).toHaveBeenCalledWith(
+        `/sessions/${sessionId}/messages`,
+        { content },
+        expect.objectContaining({
+          timeout: 180000,
+          headers: {}
+        })
+      );
+    });
+
     it('should reject empty content', async () => {
       // Arrange
       const sessionId = 'test-session-123';
@@ -762,3 +794,14 @@ describe('AgonAPIClient', () => {
     });
   });
 });
+
+function baseResponse(sessionId: string): SessionResponse {
+  return {
+    id: sessionId,
+    status: 'active',
+    phase: 'CLARIFICATION',
+    createdAt: '2026-03-08T12:00:00Z',
+    updatedAt: '2026-03-08T12:10:00Z',
+    currentRound: 1
+  };
+}

--- a/cli/test/api/agon-client.test.ts
+++ b/cli/test/api/agon-client.test.ts
@@ -548,7 +548,7 @@ describe('AgonAPIClient', () => {
         `/sessions/${sessionId}/messages`,
         { content },
         expect.objectContaining({
-          timeout: 120000,
+          timeout: 300000,
           headers: {}
         })
       );

--- a/cli/test/shell/controller.test.ts
+++ b/cli/test/shell/controller.test.ts
@@ -196,7 +196,7 @@ describe('shell controller', () => {
 
     sessionManager.getCurrentSessionId.mockResolvedValue('session-123');
     apiClient.submitMessage.mockRejectedValue(
-      new AgonError(ErrorCode.NETWORK_ERROR, 'timeout of 120000ms exceeded')
+      new AgonError(ErrorCode.TIMEOUT, 'request timed out')
     );
     apiClient.getSession.mockResolvedValue(postDeliverySession);
     apiClient.getMessages
@@ -207,8 +207,22 @@ describe('shell controller', () => {
 
     expect(apiClient.submitMessage).toHaveBeenCalledWith('session-123', 'invoke council');
     expect(apiClient.getSession).toHaveBeenCalledWith('session-123');
+    expect(sessionManager.saveSession).toHaveBeenCalledWith(postDeliverySession);
     expect(result.session.phase).toBe('PostDelivery');
     expect(result.responseMessage?.message).toBe('Council completed answer');
+  });
+
+  it('does not trigger timeout recovery for non-timeout network errors', async () => {
+    sessionManager.getCurrentSessionId.mockResolvedValue('session-123');
+    apiClient.getMessages.mockResolvedValue([]);
+    apiClient.submitMessage.mockRejectedValue(
+      new AgonError(ErrorCode.NETWORK_ERROR, 'socket hang up')
+    );
+
+    await expect(controller.submitFollowUp('invoke council')).rejects.toMatchObject({
+      code: ErrorCode.NETWORK_ERROR
+    });
+    expect(apiClient.getSession).not.toHaveBeenCalled();
   });
 
   it('recovers from stale session on follow-up by starting a fresh session', async () => {

--- a/cli/test/shell/controller.test.ts
+++ b/cli/test/shell/controller.test.ts
@@ -179,6 +179,38 @@ describe('shell controller', () => {
     expect(result.responseMessage?.message).toBe('Initial analysis from debate');
   });
 
+  it('continues polling when submit follow-up request times out client-side', async () => {
+    const oldAssistant: Message = {
+      agentId: 'post_delivery_assistant',
+      message: 'Old answer',
+      round: 2,
+      createdAt: '2026-03-10T10:00:00Z'
+    };
+    const newAssistant: Message = {
+      agentId: 'post_delivery_assistant',
+      message: 'Council completed answer',
+      round: 3,
+      createdAt: '2026-03-10T10:02:00Z'
+    };
+    const postDeliverySession: SessionResponse = { ...baseSession, phase: 'PostDelivery' };
+
+    sessionManager.getCurrentSessionId.mockResolvedValue('session-123');
+    apiClient.submitMessage.mockRejectedValue(
+      new AgonError(ErrorCode.NETWORK_ERROR, 'timeout of 120000ms exceeded')
+    );
+    apiClient.getSession.mockResolvedValue(postDeliverySession);
+    apiClient.getMessages
+      .mockResolvedValueOnce([oldAssistant]) // before submit
+      .mockResolvedValueOnce([oldAssistant, newAssistant]); // polled after timeout recovery
+
+    const result = await controller.submitFollowUp('invoke council');
+
+    expect(apiClient.submitMessage).toHaveBeenCalledWith('session-123', 'invoke council');
+    expect(apiClient.getSession).toHaveBeenCalledWith('session-123');
+    expect(result.session.phase).toBe('PostDelivery');
+    expect(result.responseMessage?.message).toBe('Council completed answer');
+  });
+
   it('recovers from stale session on follow-up by starting a fresh session', async () => {
     const freshSession: SessionResponse = {
       ...baseSession,

--- a/cli/test/utils/error-handler.test.ts
+++ b/cli/test/utils/error-handler.test.ts
@@ -37,6 +37,7 @@ describe('Error Handler', () => {
   describe('ErrorCode', () => {
     it('should have all error codes defined', () => {
       expect(ErrorCode.NETWORK_ERROR).toBe('NETWORK_ERROR');
+      expect(ErrorCode.TIMEOUT).toBe('TIMEOUT');
       expect(ErrorCode.API_ERROR).toBe('API_ERROR');
       expect(ErrorCode.SESSION_NOT_FOUND).toBe('SESSION_NOT_FOUND');
       expect(ErrorCode.INVALID_INPUT).toBe('INVALID_INPUT');
@@ -89,6 +90,11 @@ describe('Error Handler', () => {
   describe('isNetworkError', () => {
     it('should return true for network errors', () => {
       const error = new AgonError(ErrorCode.NETWORK_ERROR, 'Network failed');
+      expect(isNetworkError(error)).toBe(true);
+    });
+
+    it('should return true for timeout errors', () => {
+      const error = new AgonError(ErrorCode.TIMEOUT, 'Request timed out');
       expect(isNetworkError(error)).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
- increase CLI follow-up message request timeout from 120s to 300s for long-running council invocations
- add shell follow-up timeout recovery: when the submit request times out client-side, continue by polling session/messages instead of failing immediately
- add regression tests for both timeout configuration and timeout-recovery flow

## Root cause
`invoke council` runs through `POST /sessions/{id}/messages`, which can legitimately take longer than 120s in post-delivery council flows. The CLI treated this as a hard network failure even when backend work continued.

## Validation
- `npm --prefix cli test` ✅
- `DOTNET_CLI_HOME=/tmp dotnet test backend/Agon.sln --verbosity minimal` ✅

## Notes
- includes changeset: `cli/.changeset/fix-council-followup-timeout.md`