### PR TITLE
fix(council): decouple persistence writes from HTTP request cancellation token

### DIFF
--- a/backend/src/Agon.Application/Orchestration/AgentRunner.cs
+++ b/backend/src/Agon.Application/Orchestration/AgentRunner.cs
@@ -524,7 +524,7 @@ public sealed class AgentRunner : IAgentRunner
         var response = await RunWithTimeoutAsync(assistant, context, cancellationToken);
         await AccumulateTokensAsync(state, [response], cancellationToken);
 
-        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
+        // CancellationToken.None: history write should complete even if the HTTP client disconnected.
         if (!response.TimedOut && !string.IsNullOrWhiteSpace(response.Message))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -642,7 +642,7 @@ public sealed class AgentRunner : IAgentRunner
         await AccumulateTokensAsync(state, responses, cancellationToken);
 
         // Store all agent messages so the CLI can fetch them.
-        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
+        // CancellationToken.None: history writes should complete even if the HTTP client disconnected.
         foreach (var response in responses.Where(r => !r.TimedOut && !string.IsNullOrWhiteSpace(r.Message)))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -690,7 +690,7 @@ public sealed class AgentRunner : IAgentRunner
         await AccumulateTokensAsync(state, responses, cancellationToken);
 
         // Store all critique agent messages so the CLI can fetch them.
-        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
+        // CancellationToken.None: history writes should complete even if the HTTP client disconnected.
         foreach (var response in responses.Where(r => !r.TimedOut && !string.IsNullOrWhiteSpace(r.Message)))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -746,7 +746,7 @@ public sealed class AgentRunner : IAgentRunner
         }
 
         // Store synthesizer message so the CLI can fetch it.
-        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
+        // CancellationToken.None: history write should complete even if the HTTP client disconnected.
         if (!response.TimedOut && !string.IsNullOrWhiteSpace(response.Message))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -1448,12 +1448,13 @@ public sealed class AgentRunner : IAgentRunner
 
             try
             {
-                // Use CancellationToken.None: patch persistence must survive HTTP client disconnect / proxy timeout.
+                // CancellationToken.None: the DB write must survive HTTP client disconnect / proxy timeout.
                 state.TruthMap = await _truthMapRepository.ApplyPatchAsync(
                     state.SessionId, patch, CancellationToken.None);
 
+                // Request token for broadcast: delivery is best-effort; if the client is gone, skip it.
                 await _broadcaster.SendTruthMapPatchAsync(
-                    state.SessionId, patch, state.TruthMap.Version, CancellationToken.None);
+                    state.SessionId, patch, state.TruthMap.Version, cancellationToken);
             }
             catch (Exception ex) when (
                 ex is JsonException
@@ -1495,7 +1496,8 @@ public sealed class AgentRunner : IAgentRunner
             return;
         }
 
-        // Use CancellationToken.None: token billing writes must survive HTTP client disconnect / proxy timeout.
+        // CancellationToken.None: billing records must be written even if the HTTP client disconnected or the
+        // gateway timed out. DB command timeouts (Npgsql CommandTimeout) still bound these writes independently.
         await _tokenUsageRepository.AddRangeAsync(usageRecords, CancellationToken.None);
     }
 

--- a/backend/src/Agon.Application/Orchestration/AgentRunner.cs
+++ b/backend/src/Agon.Application/Orchestration/AgentRunner.cs
@@ -524,6 +524,7 @@ public sealed class AgentRunner : IAgentRunner
         var response = await RunWithTimeoutAsync(assistant, context, cancellationToken);
         await AccumulateTokensAsync(state, [response], cancellationToken);
 
+        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
         if (!response.TimedOut && !string.IsNullOrWhiteSpace(response.Message))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -531,7 +532,7 @@ public sealed class AgentRunner : IAgentRunner
                 assistant.AgentId,
                 response.Message,
                 state.CurrentRound,
-                cancellationToken);
+                CancellationToken.None);
         }
 
         _logger?.LogInformation(
@@ -640,7 +641,8 @@ public sealed class AgentRunner : IAgentRunner
         await ApplyPatchesAsync(state, responses, cancellationToken);
         await AccumulateTokensAsync(state, responses, cancellationToken);
 
-        // Store all agent messages so the CLI can fetch them
+        // Store all agent messages so the CLI can fetch them.
+        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
         foreach (var response in responses.Where(r => !r.TimedOut && !string.IsNullOrWhiteSpace(r.Message)))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -648,7 +650,7 @@ public sealed class AgentRunner : IAgentRunner
                 response.AgentId,
                 response.Message,
                 state.CurrentRound,
-                cancellationToken);
+                CancellationToken.None);
         }
 
         return responses;
@@ -687,7 +689,8 @@ public sealed class AgentRunner : IAgentRunner
         await ApplyPatchesAsync(state, responses, cancellationToken);
         await AccumulateTokensAsync(state, responses, cancellationToken);
 
-        // Store all critique agent messages so the CLI can fetch them
+        // Store all critique agent messages so the CLI can fetch them.
+        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
         foreach (var response in responses.Where(r => !r.TimedOut && !string.IsNullOrWhiteSpace(r.Message)))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -695,7 +698,7 @@ public sealed class AgentRunner : IAgentRunner
                 response.AgentId + "_critique",
                 response.Message,
                 state.CurrentRound,
-                cancellationToken);
+                CancellationToken.None);
         }
 
         return responses;
@@ -742,7 +745,8 @@ public sealed class AgentRunner : IAgentRunner
             }
         }
 
-        // Store synthesizer message so the CLI can fetch it
+        // Store synthesizer message so the CLI can fetch it.
+        // Use CancellationToken.None: conversation history writes must survive HTTP client disconnect / proxy timeout.
         if (!response.TimedOut && !string.IsNullOrWhiteSpace(response.Message))
         {
             await _conversationHistory.StoreMessageAsync(
@@ -750,7 +754,7 @@ public sealed class AgentRunner : IAgentRunner
                 response.AgentId,
                 response.Message,
                 state.CurrentRound,
-                cancellationToken);
+                CancellationToken.None);
         }
 
         return response;
@@ -1444,11 +1448,12 @@ public sealed class AgentRunner : IAgentRunner
 
             try
             {
+                // Use CancellationToken.None: patch persistence must survive HTTP client disconnect / proxy timeout.
                 state.TruthMap = await _truthMapRepository.ApplyPatchAsync(
-                    state.SessionId, patch, cancellationToken);
+                    state.SessionId, patch, CancellationToken.None);
 
                 await _broadcaster.SendTruthMapPatchAsync(
-                    state.SessionId, patch, state.TruthMap.Version, cancellationToken);
+                    state.SessionId, patch, state.TruthMap.Version, CancellationToken.None);
             }
             catch (Exception ex) when (
                 ex is JsonException
@@ -1490,7 +1495,8 @@ public sealed class AgentRunner : IAgentRunner
             return;
         }
 
-        await _tokenUsageRepository.AddRangeAsync(usageRecords, cancellationToken);
+        // Use CancellationToken.None: token billing writes must survive HTTP client disconnect / proxy timeout.
+        await _tokenUsageRepository.AddRangeAsync(usageRecords, CancellationToken.None);
     }
 
     private TokenUsageRecord BuildUsageRecord(

--- a/backend/src/Agon.Application/Services/SessionService.cs
+++ b/backend/src/Agon.Application/Services/SessionService.cs
@@ -259,8 +259,8 @@ public sealed class SessionService : ISessionService
             }
         }
 
-        // Persist the updated state AFTER orchestrator (to capture any state changes).
-        // Use CancellationToken.None: session state writes must survive HTTP client disconnect / proxy timeout.
+        // CancellationToken.None: session state must be persisted even if the HTTP client disconnected or the
+        // gateway timed out. DB command timeouts (Npgsql CommandTimeout) still bound this write independently.
         await _sessionRepo.UpdateAsync(state, CancellationToken.None);
     }
 

--- a/backend/src/Agon.Application/Services/SessionService.cs
+++ b/backend/src/Agon.Application/Services/SessionService.cs
@@ -259,8 +259,9 @@ public sealed class SessionService : ISessionService
             }
         }
 
-        // Persist the updated state AFTER orchestrator (to capture any state changes)
-        await _sessionRepo.UpdateAsync(state, cancellationToken);
+        // Persist the updated state AFTER orchestrator (to capture any state changes).
+        // Use CancellationToken.None: session state writes must survive HTTP client disconnect / proxy timeout.
+        await _sessionRepo.UpdateAsync(state, CancellationToken.None);
     }
 
     public async Task AdvancePhaseAsync(


### PR DESCRIPTION
## Summary

- The council + chunked-attachment prelude can take >2 minutes. Azure App Service's gateway has a ~2-minute request timeout; when it fires a **504** and drops the TCP connection, ASP.NET Core cancels the HTTP request's `CancellationToken`.
- That token flowed all the way into DB writes (`TokenUsageRepository.AddRangeAsync`, `StoreMessageAsync`, `ApplyPatchAsync`, `SessionRepo.UpdateAsync`), causing `OperationCanceledException` to bubble up as an unhandled 500 — which manifests as the **504 / "Request failed with status code 504"** you see in the CLI.
- Fix: LLM dispatch calls keep the request token (so API calls still abort cleanly on genuine user cancellation). Persistence writes switch to `CancellationToken.None` — they must always complete for billing integrity and correct session state.

## Files changed

- `Agon.Application/Orchestration/AgentRunner.cs` — `AccumulateTokensAsync`, `ApplyPatchesAsync`, `StoreMessageAsync` calls in analysis/critique/synthesis/post-delivery flows
- `Agon.Application/Services/SessionService.cs` — final `_sessionRepo.UpdateAsync` after orchestrator completes

## Test plan

- [ ] Deploy to dev, invoke council with a long attachment (>1 chunk) — confirm no 504 / `OperationCanceledException` in logs after 2 minutes
- [ ] Verify token usage records are written correctly after a council run
- [ ] Verify session state is persisted after a council run
- [ ] Verify conversation history (agent messages) are retrievable after a council run

🤖 Generated with [Claude Code](https://claude.com/claude-code)