### PR TITLE
test/release: harden CLI startup update checks and release metadata validation

### DIFF
--- a/.changeset/honest-suns-care.md
+++ b/.changeset/honest-suns-care.md
@@ -1,0 +1,9 @@
+---
+"@agon_agents/cli": patch
+---
+
+Harden startup update checks and release metadata verification.
+
+- Make shell startup update checks best-effort so transient update-check failures do not block shell startup.
+- Add explicit startup update flow tests for skip-version, no-update, install success, and install failure paths.
+- Add post-publish npm latest verification in release automation with robust path resolution and actionable failure reporting.

--- a/.github/scripts/verify-cli-release-metadata-core.mjs
+++ b/.github/scripts/verify-cli-release-metadata-core.mjs
@@ -1,0 +1,20 @@
+export function normalizeVersion(rawValue) {
+  return String(rawValue ?? '').trim();
+}
+
+export function validateLatestVersion({ expectedVersion, latestVersion }) {
+  if (!expectedVersion) {
+    throw new Error('Expected version is required.');
+  }
+
+  if (!latestVersion) {
+    throw new Error('Registry latest version is empty.');
+  }
+
+  if (latestVersion !== expectedVersion) {
+    throw new Error(
+      `Registry latest version mismatch. Expected ${expectedVersion}, got ${latestVersion}.`
+    );
+  }
+}
+

--- a/.github/scripts/verify-cli-release-metadata-core.mjs
+++ b/.github/scripts/verify-cli-release-metadata-core.mjs
@@ -18,3 +18,46 @@ export function validateLatestVersion({ expectedVersion, latestVersion }) {
   }
 }
 
+export function parseCliPackageMetadata(rawPackageJson, sourcePath) {
+  const parsed = JSON.parse(rawPackageJson);
+  const packageName = normalizeVersion(parsed.name);
+  const packageVersion = normalizeVersion(parsed.version);
+
+  if (!packageName) {
+    throw new Error(`Missing package name in ${sourcePath}.`);
+  }
+
+  if (!packageVersion) {
+    throw new Error(`Missing package version in ${sourcePath}.`);
+  }
+
+  return { packageName, packageVersion };
+}
+
+export async function fetchRegistryLatestVersion({ packageName, execFileAsyncFn }) {
+  try {
+    const { stdout } = await execFileAsyncFn('npm', ['view', `${packageName}@latest`, 'version', '--silent']);
+    return normalizeVersion(stdout);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Unable to read npm latest for ${packageName}: ${message}`);
+  }
+}
+
+export async function verifyCliReleaseMetadataCore({
+  packageJsonPath,
+  readFileFn,
+  fetchLatestVersionFn,
+  logFn = console.log
+}) {
+  const packageJsonRaw = await readFileFn(packageJsonPath, 'utf8');
+  const { packageName, packageVersion } = parseCliPackageMetadata(packageJsonRaw, packageJsonPath);
+  const latestVersion = await fetchLatestVersionFn(packageName);
+
+  validateLatestVersion({
+    expectedVersion: packageVersion,
+    latestVersion
+  });
+
+  logFn(`Verified npm latest for ${packageName}: ${latestVersion}`);
+}

--- a/.github/scripts/verify-cli-release-metadata-core.test.mjs
+++ b/.github/scripts/verify-cli-release-metadata-core.test.mjs
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  fetchRegistryLatestVersion,
   normalizeVersion,
+  parseCliPackageMetadata,
   validateLatestVersion,
+  verifyCliReleaseMetadataCore
 } from './verify-cli-release-metadata-core.mjs';
 
 test('normalizeVersion trims whitespace and line breaks', () => {
@@ -21,3 +24,38 @@ test('validateLatestVersion throws when latest does not match expected', () => {
   );
 });
 
+test('parseCliPackageMetadata reads package name/version from package.json payload', () => {
+  const result = parseCliPackageMetadata(
+    JSON.stringify({ name: '@agon_agents/cli', version: '0.9.1' }),
+    '/repo/cli/package.json'
+  );
+
+  assert.deepEqual(result, { packageName: '@agon_agents/cli', packageVersion: '0.9.1' });
+});
+
+test('fetchRegistryLatestVersion wraps npm lookup failures with actionable context', async () => {
+  await assert.rejects(
+    () =>
+      fetchRegistryLatestVersion({
+        packageName: '@agon_agents/cli',
+        execFileAsyncFn: async () => {
+          throw new Error('403 unauthorized');
+        }
+      }),
+    /Unable to read npm latest for @agon_agents\/cli: 403 unauthorized/
+  );
+});
+
+test('verifyCliReleaseMetadataCore verifies and logs when versions match', async () => {
+  const logs = [];
+
+  await verifyCliReleaseMetadataCore({
+    packageJsonPath: '/repo/cli/package.json',
+    readFileFn: async () => JSON.stringify({ name: '@agon_agents/cli', version: '0.9.1' }),
+    fetchLatestVersionFn: async () => '0.9.1',
+    logFn: (line) => logs.push(line)
+  });
+
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /Verified npm latest for @agon_agents\/cli: 0.9.1/);
+});

--- a/.github/scripts/verify-cli-release-metadata-core.test.mjs
+++ b/.github/scripts/verify-cli-release-metadata-core.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeVersion,
+  validateLatestVersion,
+} from './verify-cli-release-metadata-core.mjs';
+
+test('normalizeVersion trims whitespace and line breaks', () => {
+  assert.equal(normalizeVersion(' 0.9.1 \n'), '0.9.1');
+});
+
+test('validateLatestVersion accepts matching expected/latest versions', () => {
+  assert.doesNotThrow(() => validateLatestVersion({ expectedVersion: '0.9.1', latestVersion: '0.9.1' }));
+});
+
+test('validateLatestVersion throws when latest does not match expected', () => {
+  assert.throws(
+    () => validateLatestVersion({ expectedVersion: '0.9.1', latestVersion: '0.9.0' }),
+    /Registry latest version mismatch/
+  );
+});
+

--- a/.github/scripts/verify-cli-release-metadata.mjs
+++ b/.github/scripts/verify-cli-release-metadata.mjs
@@ -3,47 +3,32 @@
 import fs from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { normalizeVersion, validateLatestVersion } from './verify-cli-release-metadata-core.mjs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  fetchRegistryLatestVersion,
+  verifyCliReleaseMetadataCore
+} from './verify-cli-release-metadata-core.mjs';
 
 const execFileAsync = promisify(execFile);
-
-async function readCliPackageMetadata(packageJsonPath) {
-  const raw = await fs.readFile(packageJsonPath, 'utf8');
-  const parsed = JSON.parse(raw);
-
-  const packageName = normalizeVersion(parsed.name);
-  const packageVersion = normalizeVersion(parsed.version);
-
-  if (!packageName) {
-    throw new Error(`Missing package name in ${packageJsonPath}.`);
-  }
-
-  if (!packageVersion) {
-    throw new Error(`Missing package version in ${packageJsonPath}.`);
-  }
-
-  return { packageName, packageVersion };
-}
-
-async function fetchRegistryLatestVersion(packageName) {
-  const { stdout } = await execFileAsync('npm', ['view', `${packageName}@latest`, 'version', '--silent']);
-  return normalizeVersion(stdout);
-}
+const scriptFilePath = fileURLToPath(import.meta.url);
+const scriptsDirectoryPath = path.dirname(scriptFilePath);
+const repositoryRootPath = path.resolve(scriptsDirectoryPath, '..', '..');
+const cliPackageJsonPath = path.join(repositoryRootPath, 'cli', 'package.json');
 
 export async function verifyCliReleaseMetadata() {
-  const { packageName, packageVersion } = await readCliPackageMetadata('cli/package.json');
-  const latestVersion = await fetchRegistryLatestVersion(packageName);
-
-  validateLatestVersion({
-    expectedVersion: packageVersion,
-    latestVersion
+  await verifyCliReleaseMetadataCore({
+    packageJsonPath: cliPackageJsonPath,
+    readFileFn: fs.readFile,
+    fetchLatestVersionFn: (packageName) =>
+      fetchRegistryLatestVersion({
+        packageName,
+        execFileAsyncFn: execFileAsync
+      })
   });
-
-  console.log(`Verified npm latest for ${packageName}: ${latestVersion}`);
 }
 
 verifyCliReleaseMetadata().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 });
-

--- a/.github/scripts/verify-cli-release-metadata.mjs
+++ b/.github/scripts/verify-cli-release-metadata.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { normalizeVersion, validateLatestVersion } from './verify-cli-release-metadata-core.mjs';
+
+const execFileAsync = promisify(execFile);
+
+async function readCliPackageMetadata(packageJsonPath) {
+  const raw = await fs.readFile(packageJsonPath, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  const packageName = normalizeVersion(parsed.name);
+  const packageVersion = normalizeVersion(parsed.version);
+
+  if (!packageName) {
+    throw new Error(`Missing package name in ${packageJsonPath}.`);
+  }
+
+  if (!packageVersion) {
+    throw new Error(`Missing package version in ${packageJsonPath}.`);
+  }
+
+  return { packageName, packageVersion };
+}
+
+async function fetchRegistryLatestVersion(packageName) {
+  const { stdout } = await execFileAsync('npm', ['view', `${packageName}@latest`, 'version', '--silent']);
+  return normalizeVersion(stdout);
+}
+
+export async function verifyCliReleaseMetadata() {
+  const { packageName, packageVersion } = await readCliPackageMetadata('cli/package.json');
+  const latestVersion = await fetchRegistryLatestVersion(packageName);
+
+  validateLatestVersion({
+    expectedVersion: packageVersion,
+    latestVersion
+  });
+
+  console.log(`Verified npm latest for ${packageName}: ${latestVersion}`);
+}
+
+verifyCliReleaseMetadata().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
           node-version: 20
 
       - name: Run Codex review script tests
-        run: node --test .github/scripts/codex-pr-review-core.test.mjs
+        run: node --test .github/scripts/*.test.mjs
 
   cli-changeset:
     name: CLI Changeset Check

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -62,6 +62,9 @@ jobs:
 
       - name: Verify npm latest metadata for released CLI version
         if: steps.changesets.outputs.published == 'true'
+        working-directory: .
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node .github/scripts/verify-cli-release-metadata.mjs
 
       - name: Exempt changeset release PR from required checks

--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -60,6 +60,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
 
+      - name: Verify npm latest metadata for released CLI version
+        if: steps.changesets.outputs.published == 'true'
+        run: node .github/scripts/verify-cli-release-metadata.mjs
+
       - name: Exempt changeset release PR from required checks
         uses: actions/github-script@v9
         env:

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -148,39 +148,44 @@ export async function runStartupUpdateFlow(options: StartupUpdateFlowOptions): P
   const createSpinner = options.createSpinner ?? ((text: string) => ora({ text, color: 'cyan' }).start());
   const logFn = options.logFn ?? (() => undefined);
 
-  const updateInfo = await checkForCliUpdateFn({
-    packageName: options.packageName,
-    currentVersion: options.currentVersion
-  });
-  if (!updateInfo) {
-    return;
-  }
-
-  const skipVersion = await getSkippedVersionFn();
-  if (skipVersion === updateInfo.latestVersion) {
-    return;
-  }
-
-  const choice = await showUpdatePromptFn(updateInfo);
-  if (choice === 'skip-version') {
-    await setSkippedVersionFn(updateInfo.latestVersion);
-    return;
-  }
-
-  if (choice !== 'update') {
-    return;
-  }
-
-  const updateSpinner = createSpinner(`Installing ${options.packageName}@latest...`);
   try {
-    await runInstallFn(options.packageName);
-    updateSpinner.succeed(`Updated to v${updateInfo.latestVersion}.`);
-    logFn(chalk.yellow(getSelfUpdateRestartNotice(updateInfo.latestVersion)));
-  } catch (updateError) {
-    updateSpinner.fail('Update failed.');
-    const failure = describeSelfUpdateFailure(updateError);
-    logFn(chalk.red(failure.message));
-    logFn(chalk.dim(getSelfUpdateGuidance(failure.category, updateInfo.installCommand)));
+    const updateInfo = await checkForCliUpdateFn({
+      packageName: options.packageName,
+      currentVersion: options.currentVersion
+    });
+    if (!updateInfo) {
+      return;
+    }
+
+    const skipVersion = await getSkippedVersionFn();
+    if (skipVersion === updateInfo.latestVersion) {
+      return;
+    }
+
+    const choice = await showUpdatePromptFn(updateInfo);
+    if (choice === 'skip-version') {
+      await setSkippedVersionFn(updateInfo.latestVersion);
+      return;
+    }
+
+    if (choice !== 'update') {
+      return;
+    }
+
+    const updateSpinner = createSpinner(`Installing ${options.packageName}@latest...`);
+    try {
+      await runInstallFn(options.packageName);
+      updateSpinner.succeed(`Updated to v${updateInfo.latestVersion}.`);
+      logFn(chalk.yellow(getSelfUpdateRestartNotice(updateInfo.latestVersion)));
+    } catch (updateError) {
+      updateSpinner.fail('Update failed.');
+      const failure = describeSelfUpdateFailure(updateError);
+      logFn(chalk.red(failure.message));
+      logFn(chalk.dim(getSelfUpdateGuidance(failure.category, updateInfo.installCommand)));
+    }
+  } catch (updateCheckError) {
+    const message = updateCheckError instanceof Error ? updateCheckError.message : String(updateCheckError);
+    logFn(chalk.dim(`Update check skipped: ${message}`));
   }
 }
 

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -122,6 +122,68 @@ export function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
 }
 
+interface UpdateSpinner {
+  succeed(message: string): void;
+  fail(message: string): void;
+}
+
+interface StartupUpdateFlowOptions {
+  packageName: string;
+  currentVersion: string;
+  checkForCliUpdateFn?: typeof checkForCliUpdate;
+  getSkippedVersionFn?: typeof getUpdateSkipVersion;
+  showUpdatePromptFn?: typeof showUpdatePrompt;
+  setSkippedVersionFn?: typeof setUpdateSkipVersion;
+  runInstallFn?: (packageName: string) => Promise<void>;
+  createSpinner?: (text: string) => UpdateSpinner;
+  logFn?: (line: string) => void;
+}
+
+export async function runStartupUpdateFlow(options: StartupUpdateFlowOptions): Promise<void> {
+  const checkForCliUpdateFn = options.checkForCliUpdateFn ?? checkForCliUpdate;
+  const getSkippedVersionFn = options.getSkippedVersionFn ?? getUpdateSkipVersion;
+  const showUpdatePromptFn = options.showUpdatePromptFn ?? showUpdatePrompt;
+  const setSkippedVersionFn = options.setSkippedVersionFn ?? setUpdateSkipVersion;
+  const runInstallFn = options.runInstallFn ?? runNpmGlobalInstall;
+  const createSpinner = options.createSpinner ?? ((text: string) => ora({ text, color: 'cyan' }).start());
+  const logFn = options.logFn ?? (() => undefined);
+
+  const updateInfo = await checkForCliUpdateFn({
+    packageName: options.packageName,
+    currentVersion: options.currentVersion
+  });
+  if (!updateInfo) {
+    return;
+  }
+
+  const skipVersion = await getSkippedVersionFn();
+  if (skipVersion === updateInfo.latestVersion) {
+    return;
+  }
+
+  const choice = await showUpdatePromptFn(updateInfo);
+  if (choice === 'skip-version') {
+    await setSkippedVersionFn(updateInfo.latestVersion);
+    return;
+  }
+
+  if (choice !== 'update') {
+    return;
+  }
+
+  const updateSpinner = createSpinner(`Installing ${options.packageName}@latest...`);
+  try {
+    await runInstallFn(options.packageName);
+    updateSpinner.succeed(`Updated to v${updateInfo.latestVersion}.`);
+    logFn(chalk.yellow(getSelfUpdateRestartNotice(updateInfo.latestVersion)));
+  } catch (updateError) {
+    updateSpinner.fail('Update failed.');
+    const failure = describeSelfUpdateFailure(updateError);
+    logFn(chalk.red(failure.message));
+    logFn(chalk.dim(getSelfUpdateGuidance(failure.category, updateInfo.installCommand)));
+  }
+}
+
 export default class Shell extends Command {
   static override readonly description = 'Open interactive codex-style Agon shell';
 
@@ -257,28 +319,11 @@ export default class Shell extends Command {
     renderStatusLine((line) => this.log(line));
     const packageName = this.config.pjson.name ?? '@agon_agents/cli';
     const currentVersion = this.config.pjson.version ?? '0.0.0';
-    const updateInfo = await checkForCliUpdate({ packageName, currentVersion });
-    if (updateInfo) {
-      const skipVersion = await getUpdateSkipVersion();
-      if (skipVersion !== updateInfo.latestVersion) {
-        const choice = await showUpdatePrompt(updateInfo);
-        if (choice === 'skip-version') {
-          await setUpdateSkipVersion(updateInfo.latestVersion);
-        } else if (choice === 'update') {
-          const updateSpinner = ora({ text: `Installing ${packageName}@latest...`, color: 'cyan' }).start();
-          try {
-            await runNpmGlobalInstall(packageName);
-            updateSpinner.succeed(`Updated to v${updateInfo.latestVersion}.`);
-            this.log(chalk.yellow(getSelfUpdateRestartNotice(updateInfo.latestVersion)));
-          } catch (updateError) {
-            updateSpinner.fail('Update failed.');
-            const failure = describeSelfUpdateFailure(updateError);
-            this.log(chalk.red(failure.message));
-            this.log(chalk.dim(getSelfUpdateGuidance(failure.category, updateInfo.installCommand)));
-          }
-        }
-      }
-    }
+    await runStartupUpdateFlow({
+      packageName,
+      currentVersion,
+      logFn: (line) => this.log(line)
+    });
     this.log('');
 
     try {

--- a/cli/test/commands/shell-startup-update.test.ts
+++ b/cli/test/commands/shell-startup-update.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runStartupUpdateFlow } from '../../src/commands/shell.js';
+import type { CliUpdateInfo } from '../../src/utils/update-check.js';
+
+describe('runStartupUpdateFlow', () => {
+  const packageName = '@agon_agents/cli';
+  const currentVersion = '0.9.0';
+  const updateInfo: CliUpdateInfo = {
+    packageName,
+    currentVersion,
+    latestVersion: '0.9.1',
+    installCommand: 'npm install -g @agon_agents/cli@latest'
+  };
+
+  it('shows update prompt when an update is available and no skip marker exists', async () => {
+    const checkForCliUpdateFn = vi.fn().mockResolvedValue(updateInfo);
+    const getSkippedVersionFn = vi.fn().mockResolvedValue(null);
+    const showUpdatePromptFn = vi.fn().mockResolvedValue('skip');
+
+    await runStartupUpdateFlow({
+      packageName,
+      currentVersion,
+      checkForCliUpdateFn,
+      getSkippedVersionFn,
+      showUpdatePromptFn,
+      setSkippedVersionFn: vi.fn(),
+      runInstallFn: vi.fn(),
+      createSpinner: () => ({ succeed: vi.fn(), fail: vi.fn() }),
+      logFn: vi.fn()
+    });
+
+    expect(checkForCliUpdateFn).toHaveBeenCalledWith({ packageName, currentVersion });
+    expect(showUpdatePromptFn).toHaveBeenCalledWith(updateInfo);
+  });
+
+  it('does not show update prompt when latest version is already skipped', async () => {
+    const checkForCliUpdateFn = vi.fn().mockResolvedValue(updateInfo);
+    const getSkippedVersionFn = vi.fn().mockResolvedValue('0.9.1');
+    const showUpdatePromptFn = vi.fn();
+
+    await runStartupUpdateFlow({
+      packageName,
+      currentVersion,
+      checkForCliUpdateFn,
+      getSkippedVersionFn,
+      showUpdatePromptFn,
+      setSkippedVersionFn: vi.fn(),
+      runInstallFn: vi.fn(),
+      createSpinner: () => ({ succeed: vi.fn(), fail: vi.fn() }),
+      logFn: vi.fn()
+    });
+
+    expect(showUpdatePromptFn).not.toHaveBeenCalled();
+  });
+});

--- a/cli/test/commands/shell-startup-update.test.ts
+++ b/cli/test/commands/shell-startup-update.test.ts
@@ -12,10 +12,11 @@ describe('runStartupUpdateFlow', () => {
     installCommand: 'npm install -g @agon_agents/cli@latest'
   };
 
-  it('shows update prompt when an update is available and no skip marker exists', async () => {
+  it('writes skip marker when user chooses skip-version', async () => {
     const checkForCliUpdateFn = vi.fn().mockResolvedValue(updateInfo);
     const getSkippedVersionFn = vi.fn().mockResolvedValue(null);
-    const showUpdatePromptFn = vi.fn().mockResolvedValue('skip');
+    const showUpdatePromptFn = vi.fn().mockResolvedValue('skip-version');
+    const setSkippedVersionFn = vi.fn();
 
     await runStartupUpdateFlow({
       packageName,
@@ -23,7 +24,7 @@ describe('runStartupUpdateFlow', () => {
       checkForCliUpdateFn,
       getSkippedVersionFn,
       showUpdatePromptFn,
-      setSkippedVersionFn: vi.fn(),
+      setSkippedVersionFn,
       runInstallFn: vi.fn(),
       createSpinner: () => ({ succeed: vi.fn(), fail: vi.fn() }),
       logFn: vi.fn()
@@ -31,6 +32,7 @@ describe('runStartupUpdateFlow', () => {
 
     expect(checkForCliUpdateFn).toHaveBeenCalledWith({ packageName, currentVersion });
     expect(showUpdatePromptFn).toHaveBeenCalledWith(updateInfo);
+    expect(setSkippedVersionFn).toHaveBeenCalledWith('0.9.1');
   });
 
   it('does not show update prompt when latest version is already skipped', async () => {
@@ -51,5 +53,87 @@ describe('runStartupUpdateFlow', () => {
     });
 
     expect(showUpdatePromptFn).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no update is available', async () => {
+    const checkForCliUpdateFn = vi.fn().mockResolvedValue(null);
+    const showUpdatePromptFn = vi.fn();
+
+    await runStartupUpdateFlow({
+      packageName,
+      currentVersion,
+      checkForCliUpdateFn,
+      getSkippedVersionFn: vi.fn(),
+      showUpdatePromptFn,
+      setSkippedVersionFn: vi.fn(),
+      runInstallFn: vi.fn(),
+      createSpinner: () => ({ succeed: vi.fn(), fail: vi.fn() }),
+      logFn: vi.fn()
+    });
+
+    expect(showUpdatePromptFn).not.toHaveBeenCalled();
+  });
+
+  it('installs update and logs restart notice when user chooses update', async () => {
+    const runInstallFn = vi.fn().mockResolvedValue(undefined);
+    const spinner = { succeed: vi.fn(), fail: vi.fn() };
+    const logFn = vi.fn();
+
+    await runStartupUpdateFlow({
+      packageName,
+      currentVersion,
+      checkForCliUpdateFn: vi.fn().mockResolvedValue(updateInfo),
+      getSkippedVersionFn: vi.fn().mockResolvedValue(null),
+      showUpdatePromptFn: vi.fn().mockResolvedValue('update'),
+      setSkippedVersionFn: vi.fn(),
+      runInstallFn,
+      createSpinner: vi.fn().mockReturnValue(spinner),
+      logFn
+    });
+
+    expect(runInstallFn).toHaveBeenCalledWith(packageName);
+    expect(spinner.succeed).toHaveBeenCalledWith('Updated to v0.9.1.');
+    expect(logFn).toHaveBeenCalledWith(expect.stringContaining('restart Agon to use v0.9.1'));
+  });
+
+  it('logs failure guidance when update installation fails', async () => {
+    const spinner = { succeed: vi.fn(), fail: vi.fn() };
+    const logFn = vi.fn();
+
+    await runStartupUpdateFlow({
+      packageName,
+      currentVersion,
+      checkForCliUpdateFn: vi.fn().mockResolvedValue(updateInfo),
+      getSkippedVersionFn: vi.fn().mockResolvedValue(null),
+      showUpdatePromptFn: vi.fn().mockResolvedValue('update'),
+      setSkippedVersionFn: vi.fn(),
+      runInstallFn: vi.fn().mockRejectedValue(new Error('ETIMEDOUT network timeout')),
+      createSpinner: vi.fn().mockReturnValue(spinner),
+      logFn
+    });
+
+    expect(spinner.fail).toHaveBeenCalledWith('Update failed.');
+    expect(logFn).toHaveBeenCalledWith(expect.stringContaining('ETIMEDOUT network timeout'));
+    expect(logFn).toHaveBeenCalledWith(expect.stringContaining('Manual install: npm install -g @agon_agents/cli@latest'));
+  });
+
+  it('does not crash startup when update check throws', async () => {
+    const logFn = vi.fn();
+
+    await expect(
+      runStartupUpdateFlow({
+        packageName,
+        currentVersion,
+        checkForCliUpdateFn: vi.fn().mockRejectedValue(new Error('registry down')),
+        getSkippedVersionFn: vi.fn(),
+        showUpdatePromptFn: vi.fn(),
+        setSkippedVersionFn: vi.fn(),
+        runInstallFn: vi.fn(),
+        createSpinner: () => ({ succeed: vi.fn(), fail: vi.fn() }),
+        logFn
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logFn).toHaveBeenCalledWith(expect.stringContaining('Update check skipped: registry down'));
   });
 });


### PR DESCRIPTION
## Summary
Implements the two hardening actions:

1. Startup update prompt behavior is explicitly test-covered via a dedicated startup-flow unit seam.
2. Release pipeline now validates npm `latest` metadata after successful publish.

## Changes
- Refactor shell startup update logic into `runStartupUpdateFlow(...)` in `cli/src/commands/shell.ts`.
- Add focused tests for startup update behavior:
  - `cli/test/commands/shell-startup-update.test.ts`
- Add release metadata verification scripts:
  - `.github/scripts/verify-cli-release-metadata.mjs`
  - `.github/scripts/verify-cli-release-metadata-core.mjs`
  - `.github/scripts/verify-cli-release-metadata-core.test.mjs`
- Wire post-publish verification into `.github/workflows/publish-cli.yaml` (only when `steps.changesets.outputs.published == 'true'`).
- Expand script test coverage in CI to run all `.github/scripts/*.test.mjs` via `.github/workflows/ci.yaml`.

## Validation
- `npm run test -- test/commands/shell-startup-update.test.ts` ✅
- `node --test .github/scripts/*.test.mjs` ✅

No merge performed.