### PR TITLE
ci: upgrade Codex PR review model to gpt-5.4

### DIFF
--- a/.github/workflows/codex-pr-review.yaml
+++ b/.github/workflows/codex-pr-review.yaml
@@ -25,6 +25,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
-          CODEX_REVIEW_MODEL: gpt-5.2
+          CODEX_REVIEW_MODEL: gpt-5.4
           CODEX_REVIEW_DIFF_MAX: 120000
         run: node .github/scripts/codex-pr-review.mjs


### PR DESCRIPTION
## Summary
- update the `Codex PR Review` workflow to use `gpt-5.4`
- keep the existing review script behavior unchanged

## Why
`gpt-5.4` is the current frontier model for code reasoning/review quality compared to the previous `gpt-5.2` setting.

## Testing
- validated workflow file diff only (`.github/workflows/codex-pr-review.yaml`)
