### PR TITLE
feat(cli-auth): persist auth sessions and silently renew tokens

### DIFF
--- a/.changeset/curly-points-serve.md
+++ b/.changeset/curly-points-serve.md
@@ -1,0 +1,7 @@
+---
+"@agon_agents/cli": patch
+---
+
+Improve CLI auth session UX by adding silent token renewal paths and safer retry behavior.
+
+This update persists auth session metadata for non-interactive renewal, limits automatic auth retry to 401 responses, and improves compatibility for manual token sessions.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Notes:
 - `agon --self-update` updates the global CLI install from terminal.
 - `/update` runs the same update flow from inside an active shell session.
 - By default, Agon CLI connects to the hosted backend endpoint (no manual `apiUrl` setup required for end users).
-- Endpoint override precedence is: `AGON_API_URL` (explicit runtime override), then `AGON_HOSTED_API_URL`, then `AGON_API_HOSTNAME` as `https://<hostname>`, then legacy fallback.
+- Endpoint override precedence is: `AGON_API_URL` (explicit runtime override), then `AGON_HOSTED_API_URL`, then `AGON_API_HOSTNAME` as `https://<hostname>`, then the managed HTTPS default (`https://api-dev.agon-agents.org`).
 - After successful in-shell update, exit the shell and start `agon` again to run the newly installed runtime.
 - On startup, Agon checks npm and alerts when a newer stable version is available.
 - `/attach` accepts only a file path. Upload first, then send your message as a separate prompt.
@@ -419,6 +419,11 @@ agon login --token "<access-token>"
 The token is stored in `~/.agon/credentials` with mode `0600` (owner read/write
 only). It is **never** stored in `.agonrc` so that the main config file can be
 safely committed to version control.
+
+Session UX behavior:
+- After first successful `agon login`, the CLI silently reuses and renews tokens where possible (no repeated interactive prompt on every `agon` launch).
+- Device-code sessions persist refresh metadata for non-interactive renewal.
+- Azure CLI sessions are renewed with non-interactive `az account get-access-token` when needed.
 
 Additional `agon login` flags:
 

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -409,7 +409,7 @@ export class AgonAPIClient {
       return false;
     }
 
-    if (error.response.status !== 401 && error.response.status !== 403) {
+    if (error.response.status !== 401) {
       return false;
     }
 
@@ -419,8 +419,18 @@ export class AgonAPIClient {
     }
 
     cfg.__agonAuthRetryAttempted = true;
-    const refreshedToken = await this.onAuthenticationFailure();
+    let refreshedToken: string | null = null;
+    try {
+      refreshedToken = await this.onAuthenticationFailure();
+    } catch (renewalError) {
+      this.logger.debug('Silent auth renewal callback failed', {
+        reason: renewalError instanceof Error ? renewalError.message : String(renewalError),
+      });
+      return false;
+    }
+
     if (!refreshedToken?.trim()) {
+      this.logger.debug('Silent auth renewal returned no token');
       return false;
     }
 

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -42,6 +42,7 @@ export class AgonAPIClient {
   private readonly logger: Logger;
   private readonly packageName: string;
   private readonly cliVersion: string;
+  private readonly onAuthenticationFailure?: () => Promise<string | null>;
   private runtimeProfile?: RuntimeExecutionProfile;
 
   constructor(
@@ -49,12 +50,14 @@ export class AgonAPIClient {
     packageName: string = '@agon_agents/cli',
     cliVersion: string = '0.0.0',
     authToken?: string,
-    runtimeProfile?: RuntimeExecutionProfile
+    runtimeProfile?: RuntimeExecutionProfile,
+    onAuthenticationFailure?: () => Promise<string | null>
   ) {
     this.logger = new Logger('AgonAPIClient');
     this.packageName = packageName;
     this.cliVersion = cliVersion;
     this.runtimeProfile = runtimeProfile;
+    this.onAuthenticationFailure = onAuthenticationFailure;
     this.followUpTimeoutMs = resolveFollowUpTimeoutMs(process.env.AGON_FOLLOWUP_TIMEOUT_MS);
     // Resolve auth token: explicit parameter > AGON_AUTH_TOKEN env > AGON_BEARER_TOKEN env
     const resolvedAuthToken =
@@ -90,6 +93,10 @@ export class AgonAPIClient {
     this.client.interceptors.response.use(
       (response) => response,
       async (error: AxiosError) => {
+        if (await this.trySilentAuthRetry(error)) {
+          return this.client.request(error.config!);
+        }
+
         // Handle retries for network errors
         if (this.shouldRetry(error) && error.config) {
           const retryCount = (error.config as any).__retryCount || 0;
@@ -395,6 +402,49 @@ export class AgonAPIClient {
     if (!error.response) return true; // Network error
     const status = error.response.status;
     return status >= 500 && status < 600;
+  }
+
+  private async trySilentAuthRetry(error: AxiosError): Promise<boolean> {
+    if (!error.config || !error.response || !this.onAuthenticationFailure) {
+      return false;
+    }
+
+    if (error.response.status !== 401 && error.response.status !== 403) {
+      return false;
+    }
+
+    const cfg = error.config as AxiosError['config'] & { __agonAuthRetryAttempted?: boolean };
+    if (cfg.__agonAuthRetryAttempted) {
+      return false;
+    }
+
+    cfg.__agonAuthRetryAttempted = true;
+    const refreshedToken = await this.onAuthenticationFailure();
+    if (!refreshedToken?.trim()) {
+      return false;
+    }
+
+    this.setAuthToken(refreshedToken);
+    const existingHeaders = cfg.headers as unknown as { set?: (name: string, value: string) => void } | undefined;
+    if (existingHeaders?.set) {
+      existingHeaders.set('Authorization', `Bearer ${refreshedToken.trim()}`);
+    } else {
+      cfg.headers = {
+        ...(cfg.headers as Record<string, string> | undefined ?? {}),
+        Authorization: `Bearer ${refreshedToken.trim()}`
+      } as any;
+    }
+    return true;
+  }
+
+  setAuthToken(token: string): void {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      delete (this.client.defaults.headers.common as Record<string, string>).Authorization;
+      return;
+    }
+
+    (this.client.defaults.headers.common as Record<string, string>).Authorization = `Bearer ${trimmed}`;
   }
 
   private mapError(error: AxiosError): Error {

--- a/cli/src/auth/auth-manager.ts
+++ b/cli/src/auth/auth-manager.ts
@@ -16,6 +16,8 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { acquireTokenFromAzureCli } from './azure-cli-token-provider.js';
 import { refreshEntraAccessToken } from './entra-device-code-token-provider.js';
+import { SecretStore } from './secret-store.js';
+import { Logger } from '../utils/logger.js';
 
 /** Token-only representation stored on disk. */
 interface CredentialsFile {
@@ -25,6 +27,8 @@ interface CredentialsFile {
   tenant?: string;
   authority?: string;
   clientId?: string;
+  refreshTokenSecretRef?: string;
+  // Backward-compat for legacy plaintext refresh-token persistence.
   refreshToken?: string;
   expiresAt?: string;
 }
@@ -37,6 +41,7 @@ export interface AuthSessionMetadata {
   tenant?: string;
   authority?: string;
   clientId?: string;
+  refreshTokenSecretRef?: string;
   refreshToken?: string;
   expiresAt?: string;
 }
@@ -47,9 +52,16 @@ function defaultCredentialsPath(): string {
 
 export class AuthManager {
   private readonly credentialsPath: string;
+  private readonly secretStore: Pick<SecretStore, 'set' | 'get' | 'delete'>;
+  private readonly logger: Logger;
 
-  constructor(credentialsPath?: string) {
+  constructor(
+    credentialsPath?: string,
+    secretStore: Pick<SecretStore, 'set' | 'get' | 'delete'> = new SecretStore()
+  ) {
     this.credentialsPath = credentialsPath ?? defaultCredentialsPath();
+    this.secretStore = secretStore;
+    this.logger = new Logger('AuthManager');
   }
 
   /**
@@ -68,7 +80,18 @@ export class AuthManager {
     }
 
     if (isTokenExpired(credentials.expiresAt)) {
-      return this.trySilentRefresh(credentials);
+      if (!this.hasSilentRenewalStrategy(credentials)) {
+        this.logger.debug('Token expired but no silent renewal strategy is available; returning stored token');
+        return token;
+      }
+
+      this.logger.debug('Token expired; attempting silent renewal');
+      const renewed = await this.trySilentRefresh(credentials);
+      if (renewed) {
+        return renewed;
+      }
+      this.logger.debug('Silent renewal failed; returning stored token to preserve backward-compatible behavior');
+      return token;
     }
 
     return token;
@@ -85,10 +108,13 @@ export class AuthManager {
       if (!token) {
         return null;
       }
-      return {
+      const credentials = {
         ...parsed,
         authToken: token,
+        refreshTokenSecretRef: parsed.refreshTokenSecretRef?.trim() || undefined,
       };
+      await this.maybeMigrateLegacyRefreshToken(credentials);
+      return credentials;
     } catch {
       return null;
     }
@@ -107,6 +133,18 @@ export class AuthManager {
 
     await mkdir(path.dirname(this.credentialsPath), { recursive: true });
 
+    let refreshTokenSecretRef = metadata.refreshTokenSecretRef?.trim() || undefined;
+    const refreshToken = metadata.refreshToken?.trim() || undefined;
+    if (refreshToken) {
+      refreshTokenSecretRef ??= this.buildRefreshTokenSecretRef(trimmed);
+      await this.secretStore.set(refreshTokenSecretRef, refreshToken);
+      this.logger.debug('Persisted refresh token in secure secret store', { source: metadata.source ?? 'unknown' });
+    } else if (metadata.source !== 'device-code' && refreshTokenSecretRef) {
+      await this.secretStore.delete(refreshTokenSecretRef);
+      refreshTokenSecretRef = undefined;
+      this.logger.debug('Removed stale refresh-token secret reference for non-device-code session');
+    }
+
     const payload: CredentialsFile = {
       authToken: trimmed,
       source: metadata.source,
@@ -114,7 +152,7 @@ export class AuthManager {
       tenant: metadata.tenant?.trim() || undefined,
       authority: metadata.authority?.trim() || undefined,
       clientId: metadata.clientId?.trim() || undefined,
-      refreshToken: metadata.refreshToken?.trim() || undefined,
+      refreshTokenSecretRef,
       expiresAt: normalizeExpiresAt(metadata.expiresAt) ?? inferExpiresAtFromToken(trimmed),
     };
     await writeFile(
@@ -130,6 +168,11 @@ export class AuthManager {
    */
   async clearToken(): Promise<void> {
     try {
+      const existing = await this.getCredentials();
+      const refreshTokenSecretRef = existing?.refreshTokenSecretRef?.trim();
+      if (refreshTokenSecretRef) {
+        await this.secretStore.delete(refreshTokenSecretRef);
+      }
       await unlink(this.credentialsPath);
     } catch (error) {
       const err = error as NodeJS.ErrnoException;
@@ -154,6 +197,12 @@ export class AuthManager {
   async trySilentRenewal(): Promise<string | null> {
     const credentials = await this.getCredentials();
     if (!credentials) {
+      this.logger.debug('Silent renewal skipped: no credentials found');
+      return null;
+    }
+
+    if (!this.hasSilentRenewalStrategy(credentials)) {
+      this.logger.debug('Silent renewal skipped: no renewable auth session metadata found');
       return null;
     }
 
@@ -161,26 +210,38 @@ export class AuthManager {
   }
 
   private async trySilentRefresh(credentials: CredentialsFile): Promise<string | null> {
+    this.logger.debug('Attempting silent renewal with available strategies', {
+      source: credentials.source ?? 'unknown',
+    });
+
     const refreshed = await this.tryRefreshWithEntraRefreshToken(credentials);
     if (refreshed) {
+      this.logger.debug('Silent renewal succeeded using Entra refresh token flow');
       return refreshed;
     }
 
     const renewedViaAzureCli = await this.tryRefreshWithAzureCli(credentials);
     if (renewedViaAzureCli) {
+      this.logger.debug('Silent renewal succeeded using Azure CLI token flow');
       return renewedViaAzureCli;
     }
 
+    this.logger.debug('Silent renewal exhausted all strategies without success');
     return null;
   }
 
   private async tryRefreshWithEntraRefreshToken(credentials: CredentialsFile): Promise<string | null> {
     if (
       credentials.source !== 'device-code'
-      || !credentials.refreshToken?.trim()
       || !credentials.authority?.trim()
       || !credentials.clientId?.trim()
     ) {
+      return null;
+    }
+
+    const refreshToken = await this.loadRefreshToken(credentials);
+    if (!refreshToken) {
+      this.logger.debug('Entra refresh skipped: refresh token not available in secure store');
       return null;
     }
 
@@ -188,16 +249,20 @@ export class AuthManager {
       const refreshed = await refreshEntraAccessToken({
         authority: credentials.authority,
         clientId: credentials.clientId,
-        refreshToken: credentials.refreshToken,
+        refreshToken,
         scope: credentials.scope,
       });
       await this.saveToken(refreshed.accessToken, {
         ...credentials,
-        refreshToken: refreshed.refreshToken ?? credentials.refreshToken,
+        refreshTokenSecretRef: credentials.refreshTokenSecretRef,
+        refreshToken: refreshed.refreshToken ?? refreshToken,
         expiresAt: refreshed.expiresAt ?? inferExpiresAtFromToken(refreshed.accessToken),
       });
       return refreshed.accessToken;
-    } catch {
+    } catch (error) {
+      this.logger.debug('Entra refresh-token renewal failed', {
+        reason: sanitizeErrorMessage(error),
+      });
       return null;
     }
   }
@@ -218,9 +283,65 @@ export class AuthManager {
         expiresAt: inferExpiresAtFromToken(token),
       });
       return token;
-    } catch {
+    } catch (error) {
+      this.logger.debug('Azure CLI silent renewal failed', {
+        reason: sanitizeErrorMessage(error),
+      });
       return null;
     }
+  }
+
+  private hasSilentRenewalStrategy(credentials: CredentialsFile): boolean {
+    const hasDeviceCodeRefreshPath =
+      credentials.source === 'device-code'
+      && !!credentials.authority?.trim()
+      && !!credentials.clientId?.trim()
+      && (!!credentials.refreshTokenSecretRef?.trim() || !!credentials.refreshToken?.trim());
+
+    const hasAzureCliPath =
+      credentials.source === 'azure-cli'
+      && !!credentials.scope?.trim();
+
+    return hasDeviceCodeRefreshPath || hasAzureCliPath;
+  }
+
+  private async maybeMigrateLegacyRefreshToken(credentials: CredentialsFile): Promise<void> {
+    const legacyRefreshToken = credentials.refreshToken?.trim();
+    if (!legacyRefreshToken || credentials.refreshTokenSecretRef?.trim() || !credentials.authToken?.trim()) {
+      return;
+    }
+
+    const refreshTokenSecretRef = this.buildRefreshTokenSecretRef(credentials.authToken);
+    try {
+      await this.secretStore.set(refreshTokenSecretRef, legacyRefreshToken);
+      credentials.refreshTokenSecretRef = refreshTokenSecretRef;
+      delete credentials.refreshToken;
+      await writeFile(
+        this.credentialsPath,
+        JSON.stringify(credentials, null, 2),
+        { encoding: 'utf-8', mode: 0o600 }
+      );
+      this.logger.debug('Migrated legacy plaintext refresh token into secure secret store');
+    } catch (error) {
+      this.logger.debug('Failed to migrate legacy refresh token into secure store', {
+        reason: sanitizeErrorMessage(error),
+      });
+    }
+  }
+
+  private async loadRefreshToken(credentials: CredentialsFile): Promise<string | null> {
+    const ref = credentials.refreshTokenSecretRef?.trim();
+    if (ref) {
+      return this.secretStore.get(ref);
+    }
+
+    const legacy = credentials.refreshToken?.trim();
+    return legacy || null;
+  }
+
+  private buildRefreshTokenSecretRef(token: string): string {
+    const scope = inferUserScope(token);
+    return `auth-refresh:${scope}`;
   }
 }
 
@@ -289,4 +410,28 @@ function base64UrlDecode(input: string): string {
   const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
   const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
   return Buffer.from(padded, 'base64').toString('utf-8');
+}
+
+interface JwtPayloadWithIdentity extends JwtPayloadWithExpiry {
+  oid?: string;
+  sub?: string;
+}
+
+function inferUserScope(token: string): string {
+  const payload = parseJwtPayload(token) as JwtPayloadWithIdentity | null;
+  const identifier = payload?.oid?.trim() || payload?.sub?.trim();
+  if (!identifier) {
+    return 'unknown';
+  }
+
+  return identifier.toLowerCase().replace(/[^a-z0-9._-]/g, '_');
+}
+
+function sanitizeErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'unknown error';
+  }
+
+  const message = error.message || 'error';
+  return message.replace(/\s+/g, ' ').trim().slice(0, 200);
 }

--- a/cli/src/auth/auth-manager.ts
+++ b/cli/src/auth/auth-manager.ts
@@ -14,10 +14,31 @@
 import { readFile, writeFile, mkdir, unlink } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { acquireTokenFromAzureCli } from './azure-cli-token-provider.js';
+import { refreshEntraAccessToken } from './entra-device-code-token-provider.js';
 
 /** Token-only representation stored on disk. */
 interface CredentialsFile {
   authToken?: string;
+  source?: AuthTokenSource;
+  scope?: string;
+  tenant?: string;
+  authority?: string;
+  clientId?: string;
+  refreshToken?: string;
+  expiresAt?: string;
+}
+
+export type AuthTokenSource = 'manual' | 'azure-cli' | 'device-code';
+
+export interface AuthSessionMetadata {
+  source?: AuthTokenSource;
+  scope?: string;
+  tenant?: string;
+  authority?: string;
+  clientId?: string;
+  refreshToken?: string;
+  expiresAt?: string;
 }
 
 function defaultCredentialsPath(): string {
@@ -36,11 +57,38 @@ export class AuthManager {
    * Returns null when no credentials file exists or the file contains no token.
    */
   async getToken(): Promise<string | null> {
+    const credentials = await this.getCredentials();
+    if (!credentials) {
+      return null;
+    }
+
+    const token = credentials.authToken?.trim();
+    if (!token) {
+      return null;
+    }
+
+    if (isTokenExpired(credentials.expiresAt)) {
+      return this.trySilentRefresh(credentials);
+    }
+
+    return token;
+  }
+
+  /**
+   * Load full persisted auth credentials, if any.
+   */
+  async getCredentials(): Promise<CredentialsFile | null> {
     try {
       const raw = await readFile(this.credentialsPath, 'utf-8');
       const parsed: CredentialsFile = JSON.parse(raw);
       const token = parsed.authToken?.trim();
-      return token || null;
+      if (!token) {
+        return null;
+      }
+      return {
+        ...parsed,
+        authToken: token,
+      };
     } catch {
       return null;
     }
@@ -51,7 +99,7 @@ export class AuthManager {
    * Creates ~/.agon/ if it does not already exist.
    * The file is written with mode 0o600 (owner read/write only).
    */
-  async saveToken(token: string): Promise<void> {
+  async saveToken(token: string, metadata: AuthSessionMetadata = {}): Promise<void> {
     const trimmed = token.trim();
     if (!trimmed) {
       throw new Error('Token must not be empty.');
@@ -59,7 +107,16 @@ export class AuthManager {
 
     await mkdir(path.dirname(this.credentialsPath), { recursive: true });
 
-    const payload: CredentialsFile = { authToken: trimmed };
+    const payload: CredentialsFile = {
+      authToken: trimmed,
+      source: metadata.source,
+      scope: metadata.scope?.trim() || undefined,
+      tenant: metadata.tenant?.trim() || undefined,
+      authority: metadata.authority?.trim() || undefined,
+      clientId: metadata.clientId?.trim() || undefined,
+      refreshToken: metadata.refreshToken?.trim() || undefined,
+      expiresAt: normalizeExpiresAt(metadata.expiresAt) ?? inferExpiresAtFromToken(trimmed),
+    };
     await writeFile(
       this.credentialsPath,
       JSON.stringify(payload, null, 2),
@@ -89,4 +146,147 @@ export class AuthManager {
     const token = await this.getToken();
     return token !== null;
   }
+
+  /**
+   * Attempt non-interactive token renewal even if current token is not yet expired.
+   * Used as a best-effort recovery path after backend 401/403 responses.
+   */
+  async trySilentRenewal(): Promise<string | null> {
+    const credentials = await this.getCredentials();
+    if (!credentials) {
+      return null;
+    }
+
+    return this.trySilentRefresh(credentials);
+  }
+
+  private async trySilentRefresh(credentials: CredentialsFile): Promise<string | null> {
+    const refreshed = await this.tryRefreshWithEntraRefreshToken(credentials);
+    if (refreshed) {
+      return refreshed;
+    }
+
+    const renewedViaAzureCli = await this.tryRefreshWithAzureCli(credentials);
+    if (renewedViaAzureCli) {
+      return renewedViaAzureCli;
+    }
+
+    return null;
+  }
+
+  private async tryRefreshWithEntraRefreshToken(credentials: CredentialsFile): Promise<string | null> {
+    if (
+      credentials.source !== 'device-code'
+      || !credentials.refreshToken?.trim()
+      || !credentials.authority?.trim()
+      || !credentials.clientId?.trim()
+    ) {
+      return null;
+    }
+
+    try {
+      const refreshed = await refreshEntraAccessToken({
+        authority: credentials.authority,
+        clientId: credentials.clientId,
+        refreshToken: credentials.refreshToken,
+        scope: credentials.scope,
+      });
+      await this.saveToken(refreshed.accessToken, {
+        ...credentials,
+        refreshToken: refreshed.refreshToken ?? credentials.refreshToken,
+        expiresAt: refreshed.expiresAt ?? inferExpiresAtFromToken(refreshed.accessToken),
+      });
+      return refreshed.accessToken;
+    } catch {
+      return null;
+    }
+  }
+
+  private async tryRefreshWithAzureCli(credentials: CredentialsFile): Promise<string | null> {
+    if (credentials.source !== 'azure-cli' || !credentials.scope?.trim()) {
+      return null;
+    }
+
+    try {
+      const token = await acquireTokenFromAzureCli({
+        scope: credentials.scope,
+        tenant: credentials.tenant,
+        interactiveLogin: false,
+      });
+      await this.saveToken(token, {
+        ...credentials,
+        expiresAt: inferExpiresAtFromToken(token),
+      });
+      return token;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function normalizeExpiresAt(expiresAt: string | undefined): string | undefined {
+  const trimmed = expiresAt?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed.toISOString();
+}
+
+function isTokenExpired(expiresAt: string | undefined): boolean {
+  const normalized = normalizeExpiresAt(expiresAt);
+  if (!normalized) {
+    return false;
+  }
+
+  // 2-minute skew to reduce edge-case expiry races.
+  return Date.now() >= (new Date(normalized).getTime() - 2 * 60 * 1000);
+}
+
+interface JwtPayloadWithExpiry {
+  exp?: number;
+}
+
+function inferExpiresAtFromToken(token: string): string | undefined {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const payload = parseJwtPayload(trimmed);
+  if (!payload || typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) {
+    return undefined;
+  }
+
+  // exp is seconds since epoch.
+  return new Date(payload.exp * 1000).toISOString();
+}
+
+function parseJwtPayload(token: string): JwtPayloadWithExpiry | null {
+  const parts = token.split('.');
+  if (parts.length < 2) {
+    return null;
+  }
+
+  try {
+    const payloadJson = base64UrlDecode(parts[1]);
+    const payload = JSON.parse(payloadJson) as JwtPayloadWithExpiry;
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+function base64UrlDecode(input: string): string {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return Buffer.from(padded, 'base64').toString('utf-8');
 }

--- a/cli/src/auth/entra-device-code-token-provider.ts
+++ b/cli/src/auth/entra-device-code-token-provider.ts
@@ -5,6 +5,12 @@ export interface EntraDeviceCodePrompt {
   verificationUriComplete?: string;
 }
 
+export interface EntraAccessTokenBundle {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: string;
+}
+
 export interface EntraDeviceCodeTokenOptions {
   authority: string;
   tenant?: string;
@@ -33,6 +39,8 @@ interface DeviceCodeResponse {
 
 interface TokenResponse {
   access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
   error?: string;
   error_description?: string;
 }
@@ -141,6 +149,13 @@ function tokenErrorFromCode(errorCode: string, description?: string): EntraDevic
 }
 
 export async function acquireTokenFromEntraDeviceCode(options: EntraDeviceCodeTokenOptions): Promise<string> {
+  const bundle = await acquireTokenBundleFromEntraDeviceCode(options);
+  return bundle.accessToken;
+}
+
+export async function acquireTokenBundleFromEntraDeviceCode(
+  options: EntraDeviceCodeTokenOptions
+): Promise<EntraAccessTokenBundle> {
   const clientId = options.clientId.trim();
   const scope = options.scope.trim();
   if (!clientId) {
@@ -238,7 +253,11 @@ export async function acquireTokenFromEntraDeviceCode(options: EntraDeviceCodeTo
     }
 
     if (tokenResponse.access_token) {
-      return tokenResponse.access_token;
+      return {
+        accessToken: tokenResponse.access_token,
+        refreshToken: tokenResponse.refresh_token?.trim() || undefined,
+        expiresAt: resolveExpiresAt(tokenResponse.expires_in),
+      };
     }
 
     if (tokenResponse.error === 'authorization_pending') {
@@ -257,4 +276,73 @@ export async function acquireTokenFromEntraDeviceCode(options: EntraDeviceCodeTo
     'ENTRA_DEVICE_AUTH_EXPIRED',
     'Device-code sign-in timed out before token acquisition completed.',
   );
+}
+
+export interface EntraRefreshTokenOptions {
+  authority: string;
+  clientId: string;
+  refreshToken: string;
+  scope?: string;
+}
+
+export async function refreshEntraAccessToken(
+  options: EntraRefreshTokenOptions
+): Promise<EntraAccessTokenBundle> {
+  const authorityBase = normalizeEntraAuthority(options.authority);
+  const tokenEndpoint = `${authorityBase}/oauth2/v2.0/token`;
+  const clientId = options.clientId.trim();
+  const refreshToken = options.refreshToken.trim();
+
+  if (!clientId || !refreshToken) {
+    throw new EntraDeviceCodeTokenProviderError(
+      'ENTRA_DEVICE_TOKEN_FAILED',
+      'Unable to refresh Entra access token due to missing refresh token metadata.',
+    );
+  }
+
+  const payload = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: clientId,
+    refresh_token: refreshToken,
+  });
+
+  const normalizedScope = options.scope?.trim();
+  if (normalizedScope) {
+    payload.set('scope', normalizedScope);
+  }
+
+  let tokenResponse: TokenResponse;
+  try {
+    tokenResponse = await postForm(tokenEndpoint, payload) as TokenResponse;
+  } catch (error) {
+    if (error instanceof EntraDeviceCodeTokenProviderError) {
+      throw new EntraDeviceCodeTokenProviderError(
+        'ENTRA_DEVICE_TOKEN_FAILED',
+        'Failed to refresh Entra access token.',
+        error.causeDetail ?? error.message,
+      );
+    }
+    throw error;
+  }
+
+  if (!tokenResponse.access_token) {
+    throw new EntraDeviceCodeTokenProviderError(
+      'ENTRA_DEVICE_TOKEN_FAILED',
+      'Entra token refresh response did not include an access token.',
+    );
+  }
+
+  return {
+    accessToken: tokenResponse.access_token,
+    refreshToken: tokenResponse.refresh_token?.trim() || undefined,
+    expiresAt: resolveExpiresAt(tokenResponse.expires_in),
+  };
+}
+
+function resolveExpiresAt(expiresInSeconds: number | undefined): string | undefined {
+  if (typeof expiresInSeconds !== 'number' || !Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
+    return undefined;
+  }
+
+  return new Date(Date.now() + expiresInSeconds * 1000).toISOString();
 }

--- a/cli/src/commands/answer.ts
+++ b/cli/src/commands/answer.ts
@@ -95,7 +95,8 @@ export default class Answer extends Command {
         this.config.pjson.name ?? '@agon_agents/cli',
         this.config.pjson.version ?? '0.0.0',
         storedToken ?? undefined,
-        runtimeProfile.profile
+        runtimeProfile.profile,
+        () => this.authManager.trySilentRenewal()
       );
       const messagesBeforeSubmit = await apiClient.getMessages(sessionId);
       const previousAssistantMessage = getLatestPostDeliveryAssistantMessage(messagesBeforeSubmit);

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -31,12 +31,20 @@ import {
   resolveDiscoveredTenantId,
 } from '../auth/auth-discovery.js';
 import {
-  acquireTokenFromEntraDeviceCode,
+  acquireTokenBundleFromEntraDeviceCode,
   EntraDeviceCodeTokenProviderError,
 } from '../auth/entra-device-code-token-provider.js';
 import { formatTerminalLink } from '../utils/terminal-links.js';
 
 type TokenSource = 'manual' | 'azure-cli' | 'device-code';
+type TokenSessionMetadata = {
+  scope?: string;
+  tenant?: string;
+  authority?: string;
+  clientId?: string;
+  refreshToken?: string;
+  expiresAt?: string;
+};
 
 const defaultInteractiveClientId = '04b07795-8ddb-461a-bbee-02f9e1bf7b46';
 
@@ -169,17 +177,24 @@ export default class Login extends Command {
 
     let token: string;
     let tokenSource: TokenSource = 'manual';
+    let tokenMetadata: TokenSessionMetadata = {};
 
     if (flags.deviceCode) {
-      token = await this.acquireEntraDeviceCodeToken({
+      const result = await this.acquireEntraDeviceCodeToken({
         scope: resolvedScope,
         tenant: resolvedTenant,
         authority: resolvedAuthority,
         clientId: resolvedClientId,
       });
+      token = result.token;
+      tokenMetadata = result.metadata;
       tokenSource = 'device-code';
     } else if (flags.azureCli) {
       token = await this.acquireAzureCliToken(resolvedScope, resolvedTenant);
+      tokenMetadata = {
+        scope: resolvedScope || undefined,
+        tenant: resolvedTenant || undefined,
+      };
       tokenSource = 'azure-cli';
     } else if (flags.token) {
       token = flags.token.trim();
@@ -193,12 +208,14 @@ export default class Login extends Command {
         this.log(chalk.dim(`Using tenant: ${resolvedTenant}`));
       }
       this.log('');
-      token = await this.acquireEntraDeviceCodeToken({
+      const result = await this.acquireEntraDeviceCodeToken({
         scope: resolvedScope,
         tenant: resolvedTenant,
         authority: resolvedAuthority,
         clientId: resolvedClientId,
       });
+      token = result.token;
+      tokenMetadata = result.metadata;
       tokenSource = 'device-code';
     } else {
       const prompted = await this.promptForToken({
@@ -209,6 +226,7 @@ export default class Login extends Command {
       });
       token = prompted.token;
       tokenSource = prompted.source;
+      tokenMetadata = prompted.metadata;
     }
 
     const spinner = ora({ text: 'Verifying token...', color: 'cyan' }).start();
@@ -233,7 +251,15 @@ export default class Login extends Command {
       this.exit(1);
     }
 
-    await authManager.saveToken(token);
+    await authManager.saveToken(token, {
+      source: tokenSource,
+      scope: tokenMetadata.scope,
+      tenant: tokenMetadata.tenant,
+      authority: tokenMetadata.authority,
+      clientId: tokenMetadata.clientId,
+      refreshToken: tokenMetadata.refreshToken,
+      expiresAt: tokenMetadata.expiresAt,
+    });
     this.log('');
     this.log(chalk.green('✓ Token saved to ~/.agon/credentials'));
     this.log(chalk.dim('  The token will be used automatically for all future agon commands.'));
@@ -311,7 +337,7 @@ export default class Login extends Command {
     tenant: string;
     authority: string;
     clientId: string;
-  }): Promise<{ token: string; source: TokenSource }> {
+  }): Promise<{ token: string; source: TokenSource; metadata: TokenSessionMetadata }> {
     if (!process.stdin.isTTY) {
       this.error('Non-interactive login requires --token, --device-code, or --azure-cli --scope.', { exit: 1 });
     }
@@ -380,13 +406,13 @@ export default class Login extends Command {
         },
       ]);
 
-      const token = await this.acquireEntraDeviceCodeToken({
+      const result = await this.acquireEntraDeviceCodeToken({
         scope: scopeInput,
         tenant: options.tenant,
         authority: authorityInput,
         clientId: clientIdInput,
       });
-      return { token, source: 'device-code' };
+      return { token: result.token, source: 'device-code', metadata: result.metadata };
     }
 
     if (method === 'azure-cli') {
@@ -408,7 +434,14 @@ export default class Login extends Command {
       ]);
 
       const token = await this.acquireAzureCliToken(scopeInput, options.tenant);
-      return { token, source: 'azure-cli' };
+      return {
+        token,
+        source: 'azure-cli',
+        metadata: {
+          scope: scopeInput.trim() || undefined,
+          tenant: options.tenant.trim() || undefined,
+        },
+      };
     }
 
     this.log('');
@@ -432,7 +465,7 @@ export default class Login extends Command {
       }
     ]);
 
-    return { token: inputToken.trim(), source: 'manual' };
+    return { token: inputToken.trim(), source: 'manual', metadata: {} };
   }
 
   private async acquireEntraDeviceCodeToken(options: {
@@ -440,7 +473,7 @@ export default class Login extends Command {
     tenant: string;
     authority: string;
     clientId: string;
-  }): Promise<string> {
+  }): Promise<{ token: string; metadata: TokenSessionMetadata }> {
     let normalizedScope: string;
     try {
       normalizedScope = normalizeAzureScope(options.scope);
@@ -451,7 +484,7 @@ export default class Login extends Command {
 
     const spinner = ora({ text: 'Starting Entra device-code sign-in...', color: 'cyan' }).start();
     try {
-      const token = await acquireTokenFromEntraDeviceCode({
+      const bundle = await acquireTokenBundleFromEntraDeviceCode({
         authority: options.authority,
         tenant: options.tenant || undefined,
         clientId: options.clientId,
@@ -473,7 +506,17 @@ export default class Login extends Command {
       });
 
       spinner.succeed('Token acquired from Entra device-code flow');
-      return token;
+      return {
+        token: bundle.accessToken,
+        metadata: {
+          scope: normalizedScope,
+          tenant: options.tenant.trim() || undefined,
+          authority: options.authority.trim() || undefined,
+          clientId: options.clientId.trim() || undefined,
+          refreshToken: bundle.refreshToken,
+          expiresAt: bundle.expiresAt,
+        },
+      };
     } catch (error) {
       spinner.fail('Entra device-code sign-in failed');
       if (error instanceof EntraDeviceCodeTokenProviderError) {

--- a/cli/src/commands/resume.ts
+++ b/cli/src/commands/resume.ts
@@ -43,7 +43,9 @@ export default class Resume extends Command {
         config.apiUrl,
         this.config.pjson.name ?? '@agon_agents/cli',
         this.config.pjson.version ?? '0.0.0',
-        storedToken ?? undefined
+        storedToken ?? undefined,
+        undefined,
+        () => authManager.trySilentRenewal()
       );
 
       this.log('');

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -221,7 +221,8 @@ export default class Shell extends Command {
       this.config.pjson.name ?? '@agon_agents/cli',
       this.config.pjson.version ?? '0.0.0',
       storedToken ?? undefined,
-      runtimeProfile.profile
+      runtimeProfile.profile,
+      () => authManager.trySilentRenewal()
     );
     this.apiClient = apiClient;
     this.sessionManager = sessionManager;

--- a/cli/src/commands/show.ts
+++ b/cli/src/commands/show.ts
@@ -76,7 +76,9 @@ export default class Show extends Command {
         config.apiUrl,
         this.config.pjson.name ?? '@agon_agents/cli',
         this.config.pjson.version ?? '0.0.0',
-        storedToken ?? undefined
+        storedToken ?? undefined,
+        undefined,
+        () => authManager.trySilentRenewal()
       );
 
       // Determine which session to use

--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -99,7 +99,8 @@ export default class Start extends Command {
         this.config.pjson.name ?? '@agon_agents/cli',
         this.config.pjson.version ?? '0.0.0',
         storedToken ?? undefined,
-        runtimeProfile.profile
+        runtimeProfile.profile,
+        () => authManager.trySilentRenewal()
       );
 
       const hasToken = hasConfiguredAuthToken(storedToken);

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -53,7 +53,9 @@ export default class Status extends Command {
         config.apiUrl,
         this.config.pjson.name ?? '@agon_agents/cli',
         this.config.pjson.version ?? '0.0.0',
-        storedToken ?? undefined
+        storedToken ?? undefined,
+        undefined,
+        () => authManager.trySilentRenewal()
       );
 
       // Determine which session to show

--- a/cli/src/commands/usage.ts
+++ b/cli/src/commands/usage.ts
@@ -37,7 +37,9 @@ export default class Usage extends Command {
       config.apiUrl,
       this.config.pjson.name ?? '@agon_agents/cli',
       this.config.pjson.version ?? '0.0.0',
-      token ?? undefined
+      token ?? undefined,
+      undefined,
+      () => authManager.trySilentRenewal()
     );
 
     const usage = await apiClient.getUsage(flags.from, flags.to);

--- a/cli/test/api/agon-client.test.ts
+++ b/cli/test/api/agon-client.test.ts
@@ -36,6 +36,7 @@ describe('AgonAPIClient', () => {
       post: vi.fn(),
       put: vi.fn(),
       delete: vi.fn(),
+      request: vi.fn(),
       defaults: {
         headers: {
           common: {},
@@ -472,6 +473,42 @@ describe('AgonAPIClient', () => {
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token'
           })
+        })
+      );
+    });
+  });
+
+  describe('silent auth retry', () => {
+    it('retries one 401 request after silent token refresh', async () => {
+      const onAuthenticationFailure = vi.fn().mockResolvedValue('renewed-token');
+      new AgonAPIClient(
+        'http://localhost:5000',
+        '@agon_agents/cli',
+        '0.1.3',
+        'expired-token',
+        undefined,
+        onAuthenticationFailure
+      );
+
+      const responseHandlers = (mockAxios.interceptors.response.use as any).mock.calls;
+      const responseErrorHandler = responseHandlers[responseHandlers.length - 1][1];
+      const retryConfig: any = { url: '/sessions', method: 'get', headers: {} };
+      const error: any = {
+        response: { status: 401, data: {} },
+        config: retryConfig
+      };
+
+      (mockAxios.request as any).mockResolvedValue({ data: [] });
+
+      await responseErrorHandler(error);
+
+      expect(onAuthenticationFailure).toHaveBeenCalledTimes(1);
+      expect(mockAxios.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer renewed-token'
+          }),
+          __agonAuthRetryAttempted: true,
         })
       );
     });

--- a/cli/test/api/agon-client.test.ts
+++ b/cli/test/api/agon-client.test.ts
@@ -512,6 +512,52 @@ describe('AgonAPIClient', () => {
         })
       );
     });
+
+    it('does not attempt silent renewal on 403 responses', async () => {
+      const onAuthenticationFailure = vi.fn().mockResolvedValue('renewed-token');
+      new AgonAPIClient(
+        'http://localhost:5000',
+        '@agon_agents/cli',
+        '0.1.3',
+        'expired-token',
+        undefined,
+        onAuthenticationFailure
+      );
+
+      const responseHandlers = (mockAxios.interceptors.response.use as any).mock.calls;
+      const responseErrorHandler = responseHandlers[responseHandlers.length - 1][1];
+      const error: any = {
+        response: { status: 403, data: {} },
+        config: { url: '/sessions', method: 'get', headers: {} }
+      };
+
+      await expect(responseErrorHandler(error)).rejects.toThrow();
+      expect(onAuthenticationFailure).not.toHaveBeenCalled();
+      expect(mockAxios.request).not.toHaveBeenCalled();
+    });
+
+    it('falls back to mapped auth error when renewal callback throws', async () => {
+      const onAuthenticationFailure = vi.fn().mockRejectedValue(new Error('refresh failed'));
+      new AgonAPIClient(
+        'http://localhost:5000',
+        '@agon_agents/cli',
+        '0.1.3',
+        'expired-token',
+        undefined,
+        onAuthenticationFailure
+      );
+
+      const responseHandlers = (mockAxios.interceptors.response.use as any).mock.calls;
+      const responseErrorHandler = responseHandlers[responseHandlers.length - 1][1];
+      const error: any = {
+        response: { status: 401, data: {} },
+        config: { url: '/sessions', method: 'get', headers: {} }
+      };
+
+      await expect(responseErrorHandler(error)).rejects.toBeInstanceOf(AgonError);
+      expect(onAuthenticationFailure).toHaveBeenCalledTimes(1);
+      expect(mockAxios.request).not.toHaveBeenCalled();
+    });
   });
 
   describe('getMessages', () => {

--- a/cli/test/auth/auth-manager.test.ts
+++ b/cli/test/auth/auth-manager.test.ts
@@ -17,10 +17,23 @@ vi.mock('../../src/auth/entra-device-code-token-provider.js', () => ({
 
 describe('AuthManager', () => {
   const testCredentialsPath = '/tmp/test-agon/credentials';
+  let mockSecretStore: {
+    set: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+
+  const createManager = (): AuthManager =>
+    new AuthManager(testCredentialsPath, mockSecretStore as any);
 
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(os.homedir).mockReturnValue('/home/testuser');
+    mockSecretStore = {
+      set: vi.fn(),
+      get: vi.fn(),
+      delete: vi.fn(),
+    };
   });
 
   afterEach(() => {
@@ -33,7 +46,7 @@ describe('AuthManager', () => {
         Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBeNull();
@@ -42,7 +55,7 @@ describe('AuthManager', () => {
     it('returns null when credentials file has no token', async () => {
       vi.mocked(fsPromises.readFile).mockResolvedValue('{}' as any);
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBeNull();
@@ -53,7 +66,7 @@ describe('AuthManager', () => {
         JSON.stringify({ authToken: '   ' }) as any
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBeNull();
@@ -64,7 +77,7 @@ describe('AuthManager', () => {
         JSON.stringify({ authToken: 'my-secret-token' }) as any
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBe('my-secret-token');
@@ -75,7 +88,7 @@ describe('AuthManager', () => {
         JSON.stringify({ authToken: '  trimmed-token  ' }) as any
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBe('trimmed-token');
@@ -84,7 +97,7 @@ describe('AuthManager', () => {
     it('returns null when credentials file contains invalid JSON', async () => {
       vi.mocked(fsPromises.readFile).mockResolvedValue('not-valid-json' as any);
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBeNull();
@@ -96,7 +109,7 @@ describe('AuthManager', () => {
       vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
       vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await manager.saveToken('my-token');
 
       expect(fsPromises.mkdir).toHaveBeenCalledWith(
@@ -114,7 +127,7 @@ describe('AuthManager', () => {
       vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
       vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await manager.saveToken('  padded-token  ');
 
       const writtenContent = vi.mocked(fsPromises.writeFile).mock.calls[0][1] as string;
@@ -123,12 +136,12 @@ describe('AuthManager', () => {
     });
 
     it('throws when token is empty', async () => {
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await expect(manager.saveToken('')).rejects.toThrow('Token must not be empty.');
     });
 
     it('throws when token is only whitespace', async () => {
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await expect(manager.saveToken('   ')).rejects.toThrow('Token must not be empty.');
     });
   });
@@ -138,7 +151,7 @@ describe('AuthManager', () => {
       vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
       vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await manager.saveToken('my-token', {
         source: 'device-code',
         scope: 'api://test/.default',
@@ -158,12 +171,17 @@ describe('AuthManager', () => {
         authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
         tenant: 'test-tenant',
         clientId: 'test-client-id',
-        refreshToken: 'refresh-token-123',
+        refreshTokenSecretRef: expect.stringContaining('auth-refresh:'),
         expiresAt: '2099-01-01T00:00:00.000Z',
       });
+      expect(parsed.refreshToken).toBeUndefined();
+      expect(mockSecretStore.set).toHaveBeenCalledWith(
+        expect.stringContaining('auth-refresh:'),
+        'refresh-token-123'
+      );
     });
 
-    it('returns null when token is expired and no silent refresh strategy is available', async () => {
+    it('returns stored token when token is expired and no silent refresh strategy is available', async () => {
       vi.mocked(fsPromises.readFile).mockResolvedValue(
         JSON.stringify({
           authToken: 'expired-token',
@@ -172,9 +190,9 @@ describe('AuthManager', () => {
         }) as any
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
-      expect(token).toBeNull();
+      expect(token).toBe('expired-token');
     });
 
     it('silently refreshes expired device-code tokens when refresh token metadata is available', async () => {
@@ -183,7 +201,7 @@ describe('AuthManager', () => {
           authToken: 'expired-token',
           source: 'device-code',
           expiresAt: '2001-01-01T00:00:00.000Z',
-          refreshToken: 'refresh-token',
+          refreshTokenSecretRef: 'auth-refresh:test-user',
           authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
           clientId: 'client-id',
           scope: 'api://test/.default',
@@ -196,8 +214,9 @@ describe('AuthManager', () => {
         refreshToken: 'new-refresh-token',
         expiresAt: '2099-01-01T00:00:00.000Z',
       });
+      mockSecretStore.get.mockResolvedValue('refresh-token');
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBe('new-access-token');
@@ -207,6 +226,10 @@ describe('AuthManager', () => {
         refreshToken: 'refresh-token',
         scope: 'api://test/.default',
       });
+      expect(mockSecretStore.set).toHaveBeenCalledWith(
+        'auth-refresh:test-user',
+        'new-refresh-token'
+      );
       expect(fsPromises.writeFile).toHaveBeenCalled();
     });
 
@@ -224,7 +247,7 @@ describe('AuthManager', () => {
       vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
       vi.mocked(acquireTokenFromAzureCli).mockResolvedValue('azure-cli-access-token');
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       const token = await manager.getToken();
 
       expect(token).toBe('azure-cli-access-token');
@@ -235,13 +258,31 @@ describe('AuthManager', () => {
       });
       expect(fsPromises.writeFile).toHaveBeenCalled();
     });
+
+    it('returns stored token when silent renewal path exists but renewal attempt fails', async () => {
+      vi.mocked(fsPromises.readFile).mockResolvedValue(
+        JSON.stringify({
+          authToken: 'expired-token',
+          source: 'azure-cli',
+          expiresAt: '2001-01-01T00:00:00.000Z',
+          scope: 'api://test/.default',
+          tenant: 'test-tenant',
+        }) as any
+      );
+      vi.mocked(acquireTokenFromAzureCli).mockRejectedValue(new Error('az unavailable'));
+
+      const manager = createManager();
+      const token = await manager.getToken();
+
+      expect(token).toBe('expired-token');
+    });
   });
 
   describe('clearToken', () => {
     it('removes the credentials file', async () => {
       vi.mocked(fsPromises.unlink).mockResolvedValue(undefined);
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await manager.clearToken();
 
       expect(fsPromises.unlink).toHaveBeenCalledWith(testCredentialsPath);
@@ -252,7 +293,7 @@ describe('AuthManager', () => {
         Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await expect(manager.clearToken()).resolves.not.toThrow();
     });
 
@@ -261,7 +302,7 @@ describe('AuthManager', () => {
         Object.assign(new Error('Permission denied'), { code: 'EACCES' })
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       await expect(manager.clearToken()).rejects.toThrow('Permission denied');
     });
   });
@@ -272,7 +313,7 @@ describe('AuthManager', () => {
         JSON.stringify({ authToken: 'existing-token' }) as any
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       expect(await manager.hasToken()).toBe(true);
     });
 
@@ -281,7 +322,7 @@ describe('AuthManager', () => {
         Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
       );
 
-      const manager = new AuthManager(testCredentialsPath);
+      const manager = createManager();
       expect(await manager.hasToken()).toBe(false);
     });
   });

--- a/cli/test/auth/auth-manager.test.ts
+++ b/cli/test/auth/auth-manager.test.ts
@@ -3,9 +3,17 @@ import * as fsPromises from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { AuthManager } from '../../src/auth/auth-manager.js';
+import { acquireTokenFromAzureCli } from '../../src/auth/azure-cli-token-provider.js';
+import { refreshEntraAccessToken } from '../../src/auth/entra-device-code-token-provider.js';
 
 vi.mock('node:fs/promises');
 vi.mock('node:os');
+vi.mock('../../src/auth/azure-cli-token-provider.js', () => ({
+  acquireTokenFromAzureCli: vi.fn(),
+}));
+vi.mock('../../src/auth/entra-device-code-token-provider.js', () => ({
+  refreshEntraAccessToken: vi.fn(),
+}));
 
 describe('AuthManager', () => {
   const testCredentialsPath = '/tmp/test-agon/credentials';
@@ -122,6 +130,110 @@ describe('AuthManager', () => {
     it('throws when token is only whitespace', async () => {
       const manager = new AuthManager(testCredentialsPath);
       await expect(manager.saveToken('   ')).rejects.toThrow('Token must not be empty.');
+    });
+  });
+
+  describe('token lifecycle', () => {
+    it('stores auth session metadata when provided', async () => {
+      vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
+
+      const manager = new AuthManager(testCredentialsPath);
+      await manager.saveToken('my-token', {
+        source: 'device-code',
+        scope: 'api://test/.default',
+        authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
+        tenant: 'test-tenant',
+        clientId: 'test-client-id',
+        refreshToken: 'refresh-token-123',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      const writtenContent = vi.mocked(fsPromises.writeFile).mock.calls[0][1] as string;
+      const parsed = JSON.parse(writtenContent);
+      expect(parsed).toMatchObject({
+        authToken: 'my-token',
+        source: 'device-code',
+        scope: 'api://test/.default',
+        authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
+        tenant: 'test-tenant',
+        clientId: 'test-client-id',
+        refreshToken: 'refresh-token-123',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+    });
+
+    it('returns null when token is expired and no silent refresh strategy is available', async () => {
+      vi.mocked(fsPromises.readFile).mockResolvedValue(
+        JSON.stringify({
+          authToken: 'expired-token',
+          source: 'manual',
+          expiresAt: '2001-01-01T00:00:00.000Z',
+        }) as any
+      );
+
+      const manager = new AuthManager(testCredentialsPath);
+      const token = await manager.getToken();
+      expect(token).toBeNull();
+    });
+
+    it('silently refreshes expired device-code tokens when refresh token metadata is available', async () => {
+      vi.mocked(fsPromises.readFile).mockResolvedValue(
+        JSON.stringify({
+          authToken: 'expired-token',
+          source: 'device-code',
+          expiresAt: '2001-01-01T00:00:00.000Z',
+          refreshToken: 'refresh-token',
+          authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
+          clientId: 'client-id',
+          scope: 'api://test/.default',
+        }) as any
+      );
+      vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
+      vi.mocked(refreshEntraAccessToken).mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      const manager = new AuthManager(testCredentialsPath);
+      const token = await manager.getToken();
+
+      expect(token).toBe('new-access-token');
+      expect(refreshEntraAccessToken).toHaveBeenCalledWith({
+        authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
+        clientId: 'client-id',
+        refreshToken: 'refresh-token',
+        scope: 'api://test/.default',
+      });
+      expect(fsPromises.writeFile).toHaveBeenCalled();
+    });
+
+    it('silently renews expired azure-cli session tokens without interactive login', async () => {
+      vi.mocked(fsPromises.readFile).mockResolvedValue(
+        JSON.stringify({
+          authToken: 'expired-token',
+          source: 'azure-cli',
+          expiresAt: '2001-01-01T00:00:00.000Z',
+          scope: 'api://test/.default',
+          tenant: 'test-tenant',
+        }) as any
+      );
+      vi.mocked(fsPromises.mkdir).mockResolvedValue(undefined);
+      vi.mocked(fsPromises.writeFile).mockResolvedValue(undefined);
+      vi.mocked(acquireTokenFromAzureCli).mockResolvedValue('azure-cli-access-token');
+
+      const manager = new AuthManager(testCredentialsPath);
+      const token = await manager.getToken();
+
+      expect(token).toBe('azure-cli-access-token');
+      expect(acquireTokenFromAzureCli).toHaveBeenCalledWith({
+        scope: 'api://test/.default',
+        tenant: 'test-tenant',
+        interactiveLogin: false,
+      });
+      expect(fsPromises.writeFile).toHaveBeenCalled();
     });
   });
 

--- a/cli/test/auth/entra-device-code-token-provider.test.ts
+++ b/cli/test/auth/entra-device-code-token-provider.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  acquireTokenBundleFromEntraDeviceCode,
   acquireTokenFromEntraDeviceCode,
   EntraDeviceCodeTokenProviderError,
   normalizeEntraAuthority,
+  refreshEntraAccessToken,
 } from '../../src/auth/entra-device-code-token-provider.js';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -88,5 +90,62 @@ describe('acquireTokenFromEntraDeviceCode', () => {
     })).rejects.toMatchObject<Partial<EntraDeviceCodeTokenProviderError>>({
       code: 'ENTRA_DEVICE_AUTH_DECLINED',
     });
+  });
+
+  it('returns refresh token bundle when available', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        device_code: 'device-code-1',
+        user_code: 'ABCD-1234',
+        verification_uri: 'https://microsoft.com/devicelogin',
+        message: 'Use this code',
+        expires_in: 600,
+        interval: 0,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        access_token: 'access-token-123',
+        refresh_token: 'refresh-token-456',
+        expires_in: 3600,
+      }));
+
+    const tokenBundle = await acquireTokenBundleFromEntraDeviceCode({
+      authority: 'https://login.microsoftonline.com/17ca2540-dd3e-4204-b2f7-a3e3ad209719/v2.0',
+      clientId: '04b07795-8ddb-461a-bbee-02f9e1bf7b46',
+      scope: 'api://651d8078-f03e-4278-9111-dd9cd111211a/.default',
+      sleep: async () => {},
+    });
+
+    expect(tokenBundle.accessToken).toBe('access-token-123');
+    expect(tokenBundle.refreshToken).toBe('refresh-token-456');
+    expect(tokenBundle.expiresAt).toBeTruthy();
+  });
+});
+
+describe('refreshEntraAccessToken', () => {
+  const fetchMock = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('refreshes access token using refresh token grant', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      access_token: 'refreshed-access-token',
+      refresh_token: 'refreshed-refresh-token',
+      expires_in: 1800,
+    }));
+
+    const refreshed = await refreshEntraAccessToken({
+      authority: 'https://login.microsoftonline.com/test-tenant/v2.0',
+      clientId: 'test-client-id',
+      refreshToken: 'old-refresh-token',
+      scope: 'api://test/.default',
+    });
+
+    expect(refreshed.accessToken).toBe('refreshed-access-token');
+    expect(refreshed.refreshToken).toBe('refreshed-refresh-token');
+    expect(refreshed.expiresAt).toBeTruthy();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Why
Users were being prompted to run `agon login` too frequently because CLI auth used short-lived access tokens without a silent renewal lifecycle.

## What changed
- Persisted auth session metadata in `~/.agon/credentials` (source/scope/tenant/authority/clientId/expiry/refresh token when available).
- Added silent renewal paths:
  - Entra refresh-token grant for device-code sessions.
  - Non-interactive Azure CLI renewal fallback for Azure CLI sessions.
- Added one-time automatic 401/403 retry in the API client after silent renewal.
- Wired renewal callback into backend-interacting CLI commands (`shell`, `start`, `answer`, `resume`, `show`, `status`, `usage`).
- Updated authentication docs to reflect "login once, renew silently" behavior.

## Validation
- `npm run build` (CLI) passed.
- Focused tests passed:
  - `test/auth/auth-manager.test.ts`
  - `test/auth/entra-device-code-token-provider.test.ts`
  - `test/api/agon-client.test.ts`
  - `test/commands/answer.test.ts`
  - `test/commands/status.test.ts`

## Notes
- This PR contains the auth UX/session-renewal change set.
- API URL fallback cleanup remains as separate local uncommitted work in this branch and is not part of this PR commit set.