### PR TITLE
feat: complete epic #558 council reliability and cost controls

### DIFF
--- a/.changeset/cyan-geckos-taste.md
+++ b/.changeset/cyan-geckos-taste.md
@@ -1,0 +1,5 @@
+---
+"@agon_agents/cli": patch
+---
+
+Fix council watch terminal behavior so it exits cleanly when council run metadata reports completion or failure.

--- a/backend/src/Agon.Api/Configuration/AttachmentProcessingConfiguration.cs
+++ b/backend/src/Agon.Api/Configuration/AttachmentProcessingConfiguration.cs
@@ -62,17 +62,20 @@ public sealed class AttachmentChunkLoopConfiguration
 {
     public bool Enabled { get; set; } = true;
     public int ActivationThresholdChars { get; set; } = 14000;
-    public int ChunkSizeChars { get; set; } = 12000;
+    public int ChunkSizeChars { get; set; } = 9000;
     public int ChunkOverlapChars { get; set; } = 1000;
     public bool UseTokenAwareSizing { get; set; } = true;
-    public int TargetChunkTokens { get; set; } = 3000;
+    public int TargetChunkTokens { get; set; } = 2200;
     public int EstimatedCharsPerToken { get; set; } = 4;
-    public bool EnableQueryFocusedSecondPass { get; set; } = true;
-    public int MaxFocusedChunksPerAttachment { get; set; } = 3;
+    public bool EnableQueryFocusedSecondPass { get; set; } = false;
+    public int MaxFocusedChunksPerAttachment { get; set; } = 2;
     public int MinQueryKeywordLength { get; set; } = 4;
-    public int MaxChunksPerAttachment { get; set; } = 20;
-    public int MaxChunkNoteChars { get; set; } = 1200;
-    public int MaxFinalNotesPerAgent { get; set; } = 8;
+    public int MaxChunksPerAttachment { get; set; } = 12;
+    public int MaxChunkNoteChars { get; set; } = 900;
+    public int MaxFinalNotesPerAgent { get; set; } = 6;
+    public int MaxPreludePasses { get; set; } = 8;
+    public int MaxChunkBudgetChars { get; set; } = 180000;
+    public int EarlyExitMinNotesPerAgent { get; set; } = 3;
 }
 
 public sealed class AttachmentTransientRetryConfiguration

--- a/backend/src/Agon.Api/Controllers/SessionsController.cs
+++ b/backend/src/Agon.Api/Controllers/SessionsController.cs
@@ -907,7 +907,13 @@ public class SessionsController : ControllerBase
             sessionState.CurrentRound,
             sessionState.TokensUsed,
             sessionState.CreatedAt,
-            sessionState.UpdatedAt);
+            sessionState.UpdatedAt,
+            sessionState.CouncilRunPhase,
+            sessionState.CouncilRunStartedAt,
+            sessionState.CouncilRunFirstProgressAt,
+            sessionState.CouncilRunLastProgressAt,
+            sessionState.CouncilRunCompletedAt,
+            sessionState.CouncilRunFailedReason);
     }
 
     private static SessionAttachmentResponse MapAttachmentResponse(SessionAttachment attachment)
@@ -1144,7 +1150,13 @@ public record SessionResponse(
     int CurrentRound,
     int TokensUsed,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    string? CouncilRunPhase = null,
+    DateTimeOffset? CouncilRunStartedAt = null,
+    DateTimeOffset? CouncilRunFirstProgressAt = null,
+    DateTimeOffset? CouncilRunLastProgressAt = null,
+    DateTimeOffset? CouncilRunCompletedAt = null,
+    string? CouncilRunFailedReason = null);
 
 public record SnapshotResponse(
     Guid SnapshotId,

--- a/backend/src/Agon.Api/Program.cs
+++ b/backend/src/Agon.Api/Program.cs
@@ -215,7 +215,10 @@ builder.Services.AddSingleton(new AttachmentChunkLoopOptions
     MinQueryKeywordLength = attachmentProcessingConfig.ChunkLoop.MinQueryKeywordLength,
     MaxChunksPerAttachment = attachmentProcessingConfig.ChunkLoop.MaxChunksPerAttachment,
     MaxChunkNoteChars = attachmentProcessingConfig.ChunkLoop.MaxChunkNoteChars,
-    MaxFinalNotesPerAgent = attachmentProcessingConfig.ChunkLoop.MaxFinalNotesPerAgent
+    MaxFinalNotesPerAgent = attachmentProcessingConfig.ChunkLoop.MaxFinalNotesPerAgent,
+    MaxPreludePasses = attachmentProcessingConfig.ChunkLoop.MaxPreludePasses,
+    MaxChunkBudgetChars = attachmentProcessingConfig.ChunkLoop.MaxChunkBudgetChars,
+    EarlyExitMinNotesPerAgent = attachmentProcessingConfig.ChunkLoop.EarlyExitMinNotesPerAgent
 });
 builder.Services.AddSingleton(new AttachmentExtractionOptions
 {

--- a/backend/src/Agon.Api/appsettings.json
+++ b/backend/src/Agon.Api/appsettings.json
@@ -129,17 +129,20 @@
     "ChunkLoop": {
       "Enabled": true,
       "ActivationThresholdChars": 14000,
-      "ChunkSizeChars": 12000,
+      "ChunkSizeChars": 9000,
       "ChunkOverlapChars": 1000,
       "UseTokenAwareSizing": true,
-      "TargetChunkTokens": 3000,
+      "TargetChunkTokens": 2200,
       "EstimatedCharsPerToken": 4,
-      "EnableQueryFocusedSecondPass": true,
-      "MaxFocusedChunksPerAttachment": 3,
+      "EnableQueryFocusedSecondPass": false,
+      "MaxFocusedChunksPerAttachment": 2,
       "MinQueryKeywordLength": 4,
-      "MaxChunksPerAttachment": 20,
-      "MaxChunkNoteChars": 1200,
-      "MaxFinalNotesPerAgent": 8
+      "MaxChunksPerAttachment": 12,
+      "MaxChunkNoteChars": 900,
+      "MaxFinalNotesPerAgent": 6,
+      "MaxPreludePasses": 8,
+      "MaxChunkBudgetChars": 180000,
+      "EarlyExitMinNotesPerAgent": 3
     }
   },
 

--- a/backend/src/Agon.Application/Interfaces/ISessionRepository.cs
+++ b/backend/src/Agon.Application/Interfaces/ISessionRepository.cs
@@ -27,6 +27,12 @@ public interface ISessionRepository
     Task UpdateAsync(SessionState sessionState, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Persists council-run metadata fields only (phase/timestamps/failure reason) without mutating
+    /// broader session lifecycle fields such as phase/status/round/token counters.
+    /// </summary>
+    Task UpdateCouncilRunMetadataAsync(SessionState sessionState, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns all sessions belonging to the given user.
     /// Results are ordered by <c>created_at</c> descending.
     /// </summary>

--- a/backend/src/Agon.Application/Models/AgentResponse.cs
+++ b/backend/src/Agon.Application/Models/AgentResponse.cs
@@ -15,11 +15,17 @@ public sealed record AgentResponse(
     string? RawOutput,
     int PromptTokens = 0,
     int CompletionTokens = 0,
-    string TokenUsageSource = "estimated")
+    string TokenUsageSource = "estimated",
+    bool Failed = false,
+    string? FailureReason = null)
 {
     /// <summary>Creates a timed-out response stub for a specific agent.</summary>
     public static AgentResponse CreateTimedOut(string agentId) =>
         new(agentId, string.Empty, null, 0, true, null);
+
+    /// <summary>Creates a non-timeout failure response stub for a specific agent.</summary>
+    public static AgentResponse CreateFailed(string agentId, string? failureReason = null) =>
+        new(agentId, string.Empty, null, 0, false, null, Failed: true, FailureReason: failureReason);
 
     public bool HasPatch => Patch is not null;
 }

--- a/backend/src/Agon.Application/Models/SessionState.cs
+++ b/backend/src/Agon.Application/Models/SessionState.cs
@@ -23,6 +23,12 @@ public sealed class SessionState
     public int FrictionLevel { get; init; }
     public bool ResearchToolsEnabled { get; init; }
     public bool ClarificationIncomplete { get; set; }
+    public string? CouncilRunPhase { get; set; }
+    public DateTimeOffset? CouncilRunStartedAt { get; set; }
+    public DateTimeOffset? CouncilRunFirstProgressAt { get; set; }
+    public DateTimeOffset? CouncilRunLastProgressAt { get; set; }
+    public DateTimeOffset? CouncilRunCompletedAt { get; set; }
+    public string? CouncilRunFailedReason { get; set; }
     public TruthMapModel TruthMap { get; set; } = default!;
     public DebateBrief? DebateBrief { get; set; }
     public DateTimeOffset CreatedAt { get; set; }

--- a/backend/src/Agon.Application/Orchestration/AgentRunner.cs
+++ b/backend/src/Agon.Application/Orchestration/AgentRunner.cs
@@ -73,6 +73,9 @@ public sealed class AgentRunner : IAgentRunner
         Domain.Agents.AgentId.ClaudeAgent
     ];
     private const string CritiqueAgentSuffix = "_critique";
+    private const string CouncilProgressAgentId = "council_progress";
+    private const string CouncilFailedAgentId = "council_failed";
+    private const string CouncilCompleteAgentId = "council_complete";
 
     private readonly IReadOnlyList<ICouncilAgent> _agents;
     private readonly Dictionary<string, string> _modelProviderByAgentId;
@@ -574,15 +577,49 @@ public sealed class AgentRunner : IAgentRunner
             state.CurrentRound,
             CancellationToken.None);
 
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: analysis (starting)");
         var analysisResponses = await RunAnalysisRoundAsync(state, cancellationToken);
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: analysis (completed)");
         state.LastRoundMessages.Clear();
         foreach (var response in analysisResponses.Where(r => !r.TimedOut && !string.IsNullOrWhiteSpace(r.Message)))
         {
             state.LastRoundMessages[response.AgentId] = response.Message;
         }
 
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: critique (starting)");
         await RunCritiqueRoundAsync(state, cancellationToken);
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: critique (completed)");
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: synthesis (starting)");
         var synthesisResponse = await RunSynthesisAsync(state, cancellationToken);
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: synthesis (completed)");
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: completed");
+        await _conversationHistory.StoreMessageAsync(
+            state.SessionId,
+            CouncilCompleteAgentId,
+            "Council analysis completed successfully.",
+            state.CurrentRound,
+            CancellationToken.None);
 
         _logger?.LogInformation(
             "Post-delivery council invocation completed for session {SessionId}. User message length: {Length}, Tokens: {Tokens}",
@@ -922,11 +959,19 @@ public sealed class AgentRunner : IAgentRunner
     {
         var startedAt = Stopwatch.GetTimestamp();
         var notesByAgent = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-        var totalPasses = chunkedAttachments.Max(plan => plan.Chunks.Count);
+        var totalPasses = Math.Min(
+            chunkedAttachments.Max(plan => plan.Chunks.Count),
+            _chunkLoopOptions.MaxPreludePasses);
         if (totalPasses <= 0)
         {
             return notesByAgent;
         }
+
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            $"Stage: chunking (starting) — {totalPasses} base passes");
+        var earlyExited = false;
 
         for (var passIndex = 0; passIndex < totalPasses; passIndex++)
         {
@@ -935,6 +980,11 @@ public sealed class AgentRunner : IAgentRunner
             {
                 continue;
             }
+
+            await PublishCouncilProgressAsync(
+                state.SessionId,
+                state.CurrentRound,
+                $"Stage: chunking base pass {passIndex + 1}/{totalPasses}");
 
             AttachmentChunkLoopMetrics.Passes.Add(1);
 
@@ -954,20 +1004,38 @@ public sealed class AgentRunner : IAgentRunner
             var responses = await DispatchParallelAsync(councilAgents, contexts, cancellationToken);
             await AccumulateTokensAsync(state, responses, cancellationToken);
             AppendChunkPreludeNotes(notesByAgent, responses);
+            if (ShouldEarlyExitChunkPrelude(notesByAgent, councilAgents.Count))
+            {
+                await PublishCouncilProgressAsync(
+                    state.SessionId,
+                    state.CurrentRound,
+                    "Stage: chunking early-exit (note threshold reached)");
+                earlyExited = true;
+                break;
+            }
         }
 
         var latestUserQuery = state.UserMessages.Count == 0
             ? string.Empty
             : state.UserMessages[^1].Content;
         var focusedPlans = BuildQueryFocusedChunkPlans(chunkedAttachments, latestUserQuery);
-        var focusedPasses = focusedPlans.Count == 0 ? 0 : focusedPlans.Max(plan => plan.Chunks.Count);
-        for (var focusedPassIndex = 0; focusedPassIndex < focusedPasses; focusedPassIndex++)
+        var focusedPasses = focusedPlans.Count == 0
+            ? 0
+            : Math.Min(
+                focusedPlans.Max(plan => plan.Chunks.Count),
+                Math.Max(0, _chunkLoopOptions.MaxPreludePasses - totalPasses));
+        for (var focusedPassIndex = 0; focusedPassIndex < focusedPasses && !earlyExited; focusedPassIndex++)
         {
             var passAttachments = BuildChunkPassAttachments(state.Attachments, focusedPlans, focusedPassIndex);
             if (passAttachments.Count == 0)
             {
                 continue;
             }
+
+            await PublishCouncilProgressAsync(
+                state.SessionId,
+                state.CurrentRound,
+                $"Stage: chunking focused pass {focusedPassIndex + 1}/{focusedPasses}");
 
             AttachmentChunkLoopMetrics.Passes.Add(1);
 
@@ -991,8 +1059,20 @@ public sealed class AgentRunner : IAgentRunner
             var responses = await DispatchParallelAsync(councilAgents, contexts, cancellationToken);
             await AccumulateTokensAsync(state, responses, cancellationToken);
             AppendChunkPreludeNotes(notesByAgent, responses);
+            if (ShouldEarlyExitChunkPrelude(notesByAgent, councilAgents.Count))
+            {
+                await PublishCouncilProgressAsync(
+                    state.SessionId,
+                    state.CurrentRound,
+                    "Stage: chunking early-exit (note threshold reached)");
+                break;
+            }
         }
 
+        await PublishCouncilProgressAsync(
+            state.SessionId,
+            state.CurrentRound,
+            "Stage: chunking (completed)");
         AttachmentChunkLoopMetrics.PreludeDurationMs.Record(Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds);
         return notesByAgent;
     }
@@ -1137,8 +1217,14 @@ public sealed class AgentRunner : IAgentRunner
         }
 
         var plans = new List<ChunkedAttachmentPlan>();
+        var remainingBudgetChars = _chunkLoopOptions.MaxChunkBudgetChars;
         foreach (var attachment in attachments)
         {
+            if (remainingBudgetChars <= 0)
+            {
+                break;
+            }
+
             if (string.IsNullOrWhiteSpace(attachment.ExtractedText))
             {
                 continue;
@@ -1156,7 +1242,39 @@ public sealed class AgentRunner : IAgentRunner
                 continue;
             }
 
+            if (remainingBudgetChars < extractedText.Length)
+            {
+                var budgetedChunks = new List<string>();
+                var consumed = 0;
+                foreach (var chunk in chunks)
+                {
+                    if (consumed >= remainingBudgetChars)
+                    {
+                        break;
+                    }
+
+                    var budgetLeft = remainingBudgetChars - consumed;
+                    if (chunk.Length <= budgetLeft)
+                    {
+                        budgetedChunks.Add(chunk);
+                        consumed += chunk.Length;
+                        continue;
+                    }
+
+                    budgetedChunks.Add(chunk[..budgetLeft]);
+                    consumed += budgetLeft;
+                }
+
+                chunks = budgetedChunks;
+            }
+
+            if (chunks.Count <= 1)
+            {
+                continue;
+            }
+
             plans.Add(new ChunkedAttachmentPlan(attachment, chunks));
+            remainingBudgetChars -= chunks.Sum(chunk => chunk.Length);
         }
 
         return plans;
@@ -1344,6 +1462,23 @@ public sealed class AgentRunner : IAgentRunner
         return normalized[..maxChars].TrimEnd() + "...";
     }
 
+    private bool ShouldEarlyExitChunkPrelude(
+        IReadOnlyDictionary<string, List<string>> notesByAgent,
+        int councilAgentCount)
+    {
+        if (_chunkLoopOptions.EarlyExitMinNotesPerAgent <= 0)
+        {
+            return false;
+        }
+
+        if (notesByAgent.Count < councilAgentCount)
+        {
+            return false;
+        }
+
+        return notesByAgent.Values.All(notes => notes.Count >= _chunkLoopOptions.EarlyExitMinNotesPerAgent);
+    }
+
     private static AttachmentChunkLoopOptions NormalizeChunkLoopOptions(AttachmentChunkLoopOptions? options)
     {
         var source = options ?? new AttachmentChunkLoopOptions();
@@ -1364,7 +1499,10 @@ public sealed class AgentRunner : IAgentRunner
             MinQueryKeywordLength = Math.Max(1, source.MinQueryKeywordLength),
             MaxChunksPerAttachment = Math.Max(1, source.MaxChunksPerAttachment),
             MaxChunkNoteChars = Math.Max(1, source.MaxChunkNoteChars),
-            MaxFinalNotesPerAgent = Math.Max(1, source.MaxFinalNotesPerAgent)
+            MaxFinalNotesPerAgent = Math.Max(1, source.MaxFinalNotesPerAgent),
+            MaxPreludePasses = Math.Max(1, source.MaxPreludePasses),
+            MaxChunkBudgetChars = Math.Max(1, source.MaxChunkBudgetChars),
+            EarlyExitMinNotesPerAgent = Math.Max(1, source.EarlyExitMinNotesPerAgent)
         };
     }
 
@@ -1430,6 +1568,27 @@ public sealed class AgentRunner : IAgentRunner
                 agent.AgentId, _agentTimeoutSeconds);
             return AgentResponse.CreateTimedOut(agent.AgentId);
         }
+        catch (Exception ex)
+        {
+            _logger?.LogError(
+                ex,
+                "Agent {AgentId} failed unexpectedly during execution. Returning degraded response so council run can continue.",
+                agent.AgentId);
+            return AgentResponse.CreateFailed(agent.AgentId, "AGENT_EXECUTION_EXCEPTION");
+        }
+    }
+
+    private async Task PublishCouncilProgressAsync(
+        Guid sessionId,
+        int round,
+        string message)
+    {
+        await _conversationHistory.StoreMessageAsync(
+            sessionId,
+            CouncilProgressAgentId,
+            message,
+            round,
+            CancellationToken.None);
     }
 
     /// <summary>

--- a/backend/src/Agon.Application/Orchestration/AttachmentChunkLoopOptions.cs
+++ b/backend/src/Agon.Application/Orchestration/AttachmentChunkLoopOptions.cs
@@ -7,15 +7,18 @@ public sealed class AttachmentChunkLoopOptions
 {
     public bool Enabled { get; set; } = true;
     public int ActivationThresholdChars { get; set; } = 14000;
-    public int ChunkSizeChars { get; set; } = 12000;
+    public int ChunkSizeChars { get; set; } = 9000;
     public int ChunkOverlapChars { get; set; } = 1000;
     public bool UseTokenAwareSizing { get; set; } = true;
-    public int TargetChunkTokens { get; set; } = 3000;
+    public int TargetChunkTokens { get; set; } = 2200;
     public int EstimatedCharsPerToken { get; set; } = 4;
-    public bool EnableQueryFocusedSecondPass { get; set; } = true;
-    public int MaxFocusedChunksPerAttachment { get; set; } = 3;
+    public bool EnableQueryFocusedSecondPass { get; set; } = false;
+    public int MaxFocusedChunksPerAttachment { get; set; } = 2;
     public int MinQueryKeywordLength { get; set; } = 4;
-    public int MaxChunksPerAttachment { get; set; } = 20;
-    public int MaxChunkNoteChars { get; set; } = 1200;
-    public int MaxFinalNotesPerAgent { get; set; } = 8;
+    public int MaxChunksPerAttachment { get; set; } = 12;
+    public int MaxChunkNoteChars { get; set; } = 900;
+    public int MaxFinalNotesPerAgent { get; set; } = 6;
+    public int MaxPreludePasses { get; set; } = 8;
+    public int MaxChunkBudgetChars { get; set; } = 180000;
+    public int EarlyExitMinNotesPerAgent { get; set; } = 3;
 }

--- a/backend/src/Agon.Application/Orchestration/CouncilRunMetrics.cs
+++ b/backend/src/Agon.Application/Orchestration/CouncilRunMetrics.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics.Metrics;
+
+namespace Agon.Application.Orchestration;
+
+internal static class CouncilRunMetrics
+{
+    private static readonly Meter Meter = new("Agon.Application.CouncilRuns");
+
+    public static readonly Counter<long> RunStarted = Meter.CreateCounter<long>(
+        "agon_council_run_started_total",
+        unit: "{run}",
+        description: "Total number of council runs started.");
+
+    public static readonly Counter<long> FirstProgress = Meter.CreateCounter<long>(
+        "agon_council_run_first_progress_total",
+        unit: "{run}",
+        description: "Total number of council runs reaching first progress.");
+
+    public static readonly Counter<long> RunCompleted = Meter.CreateCounter<long>(
+        "agon_council_run_completed_total",
+        unit: "{run}",
+        description: "Total number of council runs completed.");
+
+    public static readonly Counter<long> RunFailed = Meter.CreateCounter<long>(
+        "agon_council_run_failed_total",
+        unit: "{run}",
+        description: "Total number of council runs failed.");
+
+    public static readonly Histogram<double> TimeToFirstProgressMs = Meter.CreateHistogram<double>(
+        "agon_council_time_to_first_progress_ms",
+        unit: "ms",
+        description: "Council run latency from start to first progress.");
+
+    public static readonly Histogram<double> RunDurationMs = Meter.CreateHistogram<double>(
+        "agon_council_run_duration_ms",
+        unit: "ms",
+        description: "Council run duration from start to terminal state.");
+
+    public static readonly Histogram<double> StageDurationMs = Meter.CreateHistogram<double>(
+        "agon_council_stage_duration_ms",
+        unit: "ms",
+        description: "Observed duration spent in each council stage.");
+}

--- a/backend/src/Agon.Application/Orchestration/Orchestrator.cs
+++ b/backend/src/Agon.Application/Orchestration/Orchestrator.cs
@@ -188,6 +188,14 @@ public sealed class Orchestrator : IOrchestrator
                 _logger?.LogInformation(
                     "Session {SessionId}: Post-delivery council already running — duplicate invocation ignored.",
                     sessionId);
+                using var duplicateScope = _scopeFactory.CreateScope();
+                var duplicateHistory = duplicateScope.ServiceProvider.GetRequiredService<ConversationHistoryService>();
+                await duplicateHistory.StoreMessageAsync(
+                    sessionId,
+                    "council_progress",
+                    "Stage: already running (duplicate invoke ignored)",
+                    state.CurrentRound,
+                    CancellationToken.None);
                 return;
             }
 
@@ -219,6 +227,27 @@ public sealed class Orchestrator : IOrchestrator
                         ex,
                         "Session {SessionId}: Post-delivery council failed in background.",
                         sessionId);
+                    try
+                    {
+                        using var failureScope = _scopeFactory.CreateScope();
+                        var history = failureScope.ServiceProvider.GetRequiredService<ConversationHistoryService>();
+                        var scopedSessionService = failureScope.ServiceProvider.GetRequiredService<ISessionService>();
+                        var scopedState = await scopedSessionService.GetAsync(sessionId, CancellationToken.None);
+                        var round = scopedState?.CurrentRound ?? state.CurrentRound;
+                        await history.StoreMessageAsync(
+                            sessionId,
+                            "council_failed",
+                            "Council run failed (ReasonCode=COUNCIL_BACKGROUND_FAILURE). You can retry by sending 'invoke council' again.",
+                            round,
+                            CancellationToken.None);
+                    }
+                    catch (Exception persistFailureEx)
+                    {
+                        _logger?.LogError(
+                            persistFailureEx,
+                            "Session {SessionId}: Failed to persist council failure message.",
+                            sessionId);
+                    }
                 }
                 finally
                 {

--- a/backend/src/Agon.Application/Services/ConversationHistoryService.cs
+++ b/backend/src/Agon.Application/Services/ConversationHistoryService.cs
@@ -1,7 +1,7 @@
 using Agon.Application.Interfaces;
 using Agon.Application.Models;
-using Agon.Domain.Sessions;
 using Agon.Application.Orchestration;
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
 namespace Agon.Application.Services;
@@ -12,12 +12,15 @@ namespace Agon.Application.Services;
 /// </summary>
 public sealed class ConversationHistoryService
 {
+    private sealed record StageTiming(string Phase, DateTimeOffset StartedAt);
+
     private static readonly Regex StageRegex = new(
         @"\bstage\s*:\s*([a-z_]+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
     private static readonly Regex ReasonCodeRegex = new(
         @"\bReasonCode=([A-Z0-9_]+)",
         RegexOptions.Compiled);
+    private static readonly ConcurrentDictionary<Guid, StageTiming> StageTimings = new();
 
     private readonly IAgentMessageRepository _messageRepo;
     private readonly ISessionRepository? _sessionRepo;
@@ -97,22 +100,17 @@ public sealed class ConversationHistoryService
         }
 
         var now = DateTimeOffset.UtcNow;
-        var previousPhase = state.CouncilRunPhase;
-        var previousLastProgress = state.CouncilRunLastProgressAt;
 
         if (normalizedAgentId == "council_running")
         {
-            if (state.CouncilRunStartedAt is null)
-            {
-                state.CouncilRunStartedAt = now;
-                CouncilRunMetrics.RunStarted.Add(1);
-            }
-
+            state.CouncilRunStartedAt = now;
             state.CouncilRunPhase = "queued";
             state.CouncilRunFirstProgressAt = null;
             state.CouncilRunLastProgressAt = now;
             state.CouncilRunCompletedAt = null;
             state.CouncilRunFailedReason = null;
+            StageTimings[sessionId] = new StageTiming("queued", now);
+            CouncilRunMetrics.RunStarted.Add(1);
         }
         else if (normalizedAgentId == "council_progress")
         {
@@ -133,8 +131,37 @@ public sealed class ConversationHistoryService
                 }
             }
 
-            state.CouncilRunPhase = ExtractStage(message);
+            var previousPhase = state.CouncilRunPhase;
+            var currentStage = ExtractStage(message);
+            var phaseChanged = !string.Equals(previousPhase, currentStage, StringComparison.OrdinalIgnoreCase);
+
+            if (phaseChanged
+                && StageTimings.TryGetValue(sessionId, out var priorTiming)
+                && !string.IsNullOrWhiteSpace(priorTiming.Phase))
+            {
+                RecordStageDuration(priorTiming.Phase, now - priorTiming.StartedAt);
+            }
+
+            if (phaseChanged
+                || IsStageStartingMessage(message)
+                || !StageTimings.TryGetValue(sessionId, out var activeTiming)
+                || !string.Equals(activeTiming.Phase, currentStage, StringComparison.OrdinalIgnoreCase))
+            {
+                StageTimings[sessionId] = new StageTiming(currentStage, now);
+            }
+
+            if (IsStageCompletedMessage(message)
+                && StageTimings.TryGetValue(sessionId, out var completedTiming)
+                && string.Equals(completedTiming.Phase, currentStage, StringComparison.OrdinalIgnoreCase))
+            {
+                RecordStageDuration(currentStage, now - completedTiming.StartedAt);
+                StageTimings.TryRemove(sessionId, out _);
+            }
+
+            state.CouncilRunPhase = currentStage;
             state.CouncilRunLastProgressAt = now;
+            state.CouncilRunCompletedAt = null;
+            state.CouncilRunFailedReason = null;
         }
         else if (normalizedAgentId == "council_complete")
         {
@@ -143,6 +170,12 @@ public sealed class ConversationHistoryService
                 state.CouncilRunStartedAt = now;
                 CouncilRunMetrics.RunStarted.Add(1);
             }
+
+            if (StageTimings.TryGetValue(sessionId, out var lastStageTiming))
+            {
+                RecordStageDuration(lastStageTiming.Phase, now - lastStageTiming.StartedAt);
+            }
+            StageTimings.TryRemove(sessionId, out _);
 
             state.CouncilRunPhase = "completed";
             state.CouncilRunLastProgressAt = now;
@@ -163,7 +196,12 @@ public sealed class ConversationHistoryService
                 CouncilRunMetrics.RunStarted.Add(1);
             }
 
-            state.Status = SessionStatus.CompleteWithGaps;
+            if (StageTimings.TryGetValue(sessionId, out var failedStageTiming))
+            {
+                RecordStageDuration(failedStageTiming.Phase, now - failedStageTiming.StartedAt);
+            }
+            StageTimings.TryRemove(sessionId, out _);
+
             state.CouncilRunPhase = "failed";
             state.CouncilRunLastProgressAt = now;
             state.CouncilRunCompletedAt = now;
@@ -178,16 +216,7 @@ public sealed class ConversationHistoryService
             }
         }
 
-        if (!string.Equals(previousPhase, state.CouncilRunPhase, StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrWhiteSpace(previousPhase)
-            && previousLastProgress.HasValue)
-        {
-            CouncilRunMetrics.StageDurationMs.Record(
-                Math.Max(0, (now - previousLastProgress.Value).TotalMilliseconds),
-                new KeyValuePair<string, object?>("stage", previousPhase));
-        }
-
-        await _sessionRepo.UpdateAsync(state, cancellationToken);
+        await _sessionRepo.UpdateCouncilRunMetadataAsync(state, cancellationToken);
     }
 
     private static string ExtractStage(string message)
@@ -205,5 +234,23 @@ public sealed class ConversationHistoryService
     {
         var match = ReasonCodeRegex.Match(message);
         return match.Success ? match.Groups[1].Value.Trim().ToUpperInvariant() : null;
+    }
+
+    private static bool IsStageStartingMessage(string message) =>
+        message.Contains("(starting)", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsStageCompletedMessage(string message) =>
+        message.Contains("(completed)", StringComparison.OrdinalIgnoreCase);
+
+    private static void RecordStageDuration(string phase, TimeSpan duration)
+    {
+        if (string.IsNullOrWhiteSpace(phase))
+        {
+            return;
+        }
+
+        CouncilRunMetrics.StageDurationMs.Record(
+            Math.Max(0, duration.TotalMilliseconds),
+            new KeyValuePair<string, object?>("stage", phase));
     }
 }

--- a/backend/src/Agon.Application/Services/ConversationHistoryService.cs
+++ b/backend/src/Agon.Application/Services/ConversationHistoryService.cs
@@ -1,5 +1,8 @@
 using Agon.Application.Interfaces;
 using Agon.Application.Models;
+using Agon.Domain.Sessions;
+using Agon.Application.Orchestration;
+using System.Text.RegularExpressions;
 
 namespace Agon.Application.Services;
 
@@ -9,11 +12,22 @@ namespace Agon.Application.Services;
 /// </summary>
 public sealed class ConversationHistoryService
 {
-    private readonly IAgentMessageRepository _messageRepo;
+    private static readonly Regex StageRegex = new(
+        @"\bstage\s*:\s*([a-z_]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex ReasonCodeRegex = new(
+        @"\bReasonCode=([A-Z0-9_]+)",
+        RegexOptions.Compiled);
 
-    public ConversationHistoryService(IAgentMessageRepository messageRepo)
+    private readonly IAgentMessageRepository _messageRepo;
+    private readonly ISessionRepository? _sessionRepo;
+
+    public ConversationHistoryService(
+        IAgentMessageRepository messageRepo,
+        ISessionRepository? sessionRepo = null)
     {
         _messageRepo = messageRepo ?? throw new ArgumentNullException(nameof(messageRepo));
+        _sessionRepo = sessionRepo;
     }
 
     /// <summary>
@@ -41,6 +55,8 @@ public sealed class ConversationHistoryService
             CreatedAt: DateTimeOffset.UtcNow);
 
         await _messageRepo.AddAsync(record, cancellationToken);
+
+        await TryPersistCouncilRunStateAsync(sessionId, agentId, message, cancellationToken);
     }
 
     /// <summary>
@@ -51,5 +67,143 @@ public sealed class ConversationHistoryService
         CancellationToken cancellationToken)
     {
         return await _messageRepo.GetBySessionIdAsync(sessionId, cancellationToken);
+    }
+
+    private async Task TryPersistCouncilRunStateAsync(
+        Guid sessionId,
+        string agentId,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        if (_sessionRepo is null)
+        {
+            return;
+        }
+
+        var normalizedAgentId = agentId.Trim().ToLowerInvariant();
+        var isCouncilRunEvent = normalizedAgentId is "council_running"
+            or "council_progress"
+            or "council_failed"
+            or "council_complete";
+        if (!isCouncilRunEvent)
+        {
+            return;
+        }
+
+        var state = await _sessionRepo.GetAsync(sessionId, cancellationToken);
+        if (state is null)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var previousPhase = state.CouncilRunPhase;
+        var previousLastProgress = state.CouncilRunLastProgressAt;
+
+        if (normalizedAgentId == "council_running")
+        {
+            if (state.CouncilRunStartedAt is null)
+            {
+                state.CouncilRunStartedAt = now;
+                CouncilRunMetrics.RunStarted.Add(1);
+            }
+
+            state.CouncilRunPhase = "queued";
+            state.CouncilRunFirstProgressAt = null;
+            state.CouncilRunLastProgressAt = now;
+            state.CouncilRunCompletedAt = null;
+            state.CouncilRunFailedReason = null;
+        }
+        else if (normalizedAgentId == "council_progress")
+        {
+            if (state.CouncilRunStartedAt is null)
+            {
+                state.CouncilRunStartedAt = now;
+                CouncilRunMetrics.RunStarted.Add(1);
+            }
+
+            if (state.CouncilRunFirstProgressAt is null)
+            {
+                state.CouncilRunFirstProgressAt = now;
+                CouncilRunMetrics.FirstProgress.Add(1);
+                if (state.CouncilRunStartedAt.HasValue)
+                {
+                    CouncilRunMetrics.TimeToFirstProgressMs.Record(
+                        Math.Max(0, (now - state.CouncilRunStartedAt.Value).TotalMilliseconds));
+                }
+            }
+
+            state.CouncilRunPhase = ExtractStage(message);
+            state.CouncilRunLastProgressAt = now;
+        }
+        else if (normalizedAgentId == "council_complete")
+        {
+            if (state.CouncilRunStartedAt is null)
+            {
+                state.CouncilRunStartedAt = now;
+                CouncilRunMetrics.RunStarted.Add(1);
+            }
+
+            state.CouncilRunPhase = "completed";
+            state.CouncilRunLastProgressAt = now;
+            state.CouncilRunCompletedAt = now;
+            state.CouncilRunFailedReason = null;
+            CouncilRunMetrics.RunCompleted.Add(1);
+            if (state.CouncilRunStartedAt.HasValue)
+            {
+                CouncilRunMetrics.RunDurationMs.Record(
+                    Math.Max(0, (now - state.CouncilRunStartedAt.Value).TotalMilliseconds));
+            }
+        }
+        else
+        {
+            if (state.CouncilRunStartedAt is null)
+            {
+                state.CouncilRunStartedAt = now;
+                CouncilRunMetrics.RunStarted.Add(1);
+            }
+
+            state.Status = SessionStatus.CompleteWithGaps;
+            state.CouncilRunPhase = "failed";
+            state.CouncilRunLastProgressAt = now;
+            state.CouncilRunCompletedAt = now;
+            state.CouncilRunFailedReason = ExtractReasonCode(message);
+            CouncilRunMetrics.RunFailed.Add(
+                1,
+                new KeyValuePair<string, object?>("reason_code", state.CouncilRunFailedReason ?? "UNKNOWN"));
+            if (state.CouncilRunStartedAt.HasValue)
+            {
+                CouncilRunMetrics.RunDurationMs.Record(
+                    Math.Max(0, (now - state.CouncilRunStartedAt.Value).TotalMilliseconds));
+            }
+        }
+
+        if (!string.Equals(previousPhase, state.CouncilRunPhase, StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(previousPhase)
+            && previousLastProgress.HasValue)
+        {
+            CouncilRunMetrics.StageDurationMs.Record(
+                Math.Max(0, (now - previousLastProgress.Value).TotalMilliseconds),
+                new KeyValuePair<string, object?>("stage", previousPhase));
+        }
+
+        await _sessionRepo.UpdateAsync(state, cancellationToken);
+    }
+
+    private static string ExtractStage(string message)
+    {
+        var match = StageRegex.Match(message);
+        if (!match.Success)
+        {
+            return "analysis";
+        }
+
+        return match.Groups[1].Value.Trim().ToLowerInvariant();
+    }
+
+    private static string? ExtractReasonCode(string message)
+    {
+        var match = ReasonCodeRegex.Match(message);
+        return match.Success ? match.Groups[1].Value.Trim().ToUpperInvariant() : null;
     }
 }

--- a/backend/src/Agon.Infrastructure/Migrations/20260417080000_AddCouncilRunMetadata.cs
+++ b/backend/src/Agon.Infrastructure/Migrations/20260417080000_AddCouncilRunMetadata.cs
@@ -1,0 +1,79 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Agon.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCouncilRunMetadata : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "council_run_completed_at",
+                table: "sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "council_run_failed_reason",
+                table: "sessions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "council_run_first_progress_at",
+                table: "sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "council_run_last_progress_at",
+                table: "sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "council_run_phase",
+                table: "sessions",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "council_run_started_at",
+                table: "sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "council_run_completed_at",
+                table: "sessions");
+
+            migrationBuilder.DropColumn(
+                name: "council_run_failed_reason",
+                table: "sessions");
+
+            migrationBuilder.DropColumn(
+                name: "council_run_first_progress_at",
+                table: "sessions");
+
+            migrationBuilder.DropColumn(
+                name: "council_run_last_progress_at",
+                table: "sessions");
+
+            migrationBuilder.DropColumn(
+                name: "council_run_phase",
+                table: "sessions");
+
+            migrationBuilder.DropColumn(
+                name: "council_run_started_at",
+                table: "sessions");
+        }
+    }
+}

--- a/backend/src/Agon.Infrastructure/Migrations/AgonDbContextModelSnapshot.cs
+++ b/backend/src/Agon.Infrastructure/Migrations/AgonDbContextModelSnapshot.cs
@@ -344,6 +344,30 @@ namespace Agon.Infrastructure.Migrations
                         .HasColumnType("integer")
                         .HasColumnName("ClarificationRoundCount");
 
+                    b.Property<DateTime?>("CouncilRunCompletedAt")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("council_run_completed_at");
+
+                    b.Property<string>("CouncilRunFailedReason")
+                        .HasColumnType("text")
+                        .HasColumnName("council_run_failed_reason");
+
+                    b.Property<DateTime?>("CouncilRunFirstProgressAt")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("council_run_first_progress_at");
+
+                    b.Property<DateTime?>("CouncilRunLastProgressAt")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("council_run_last_progress_at");
+
+                    b.Property<string>("CouncilRunPhase")
+                        .HasColumnType("text")
+                        .HasColumnName("council_run_phase");
+
+                    b.Property<DateTime?>("CouncilRunStartedAt")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("council_run_started_at");
+
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_at");

--- a/backend/src/Agon.Infrastructure/Persistence/PostgreSQL/AgonDbContext.cs
+++ b/backend/src/Agon.Infrastructure/Persistence/PostgreSQL/AgonDbContext.cs
@@ -92,6 +92,12 @@ public class AgonDbContext : DbContext
             entity.Property(e => e.TargetedLoopCount).HasColumnName("targeted_loop_count");
             entity.Property(e => e.ClarificationIncomplete).HasColumnName("clarification_incomplete");
             entity.Property(e => e.ClarificationRoundCount).HasColumnName("ClarificationRoundCount");
+            entity.Property(e => e.CouncilRunPhase).HasColumnName("council_run_phase");
+            entity.Property(e => e.CouncilRunStartedAt).HasColumnName("council_run_started_at");
+            entity.Property(e => e.CouncilRunFirstProgressAt).HasColumnName("council_run_first_progress_at");
+            entity.Property(e => e.CouncilRunLastProgressAt).HasColumnName("council_run_last_progress_at");
+            entity.Property(e => e.CouncilRunCompletedAt).HasColumnName("council_run_completed_at");
+            entity.Property(e => e.CouncilRunFailedReason).HasColumnName("council_run_failed_reason");
             entity.Property(e => e.ForkedFrom).HasColumnName("forked_from");
             entity.Property(e => e.ForkSnapshotId).HasColumnName("fork_snapshot_id");
             entity.Property(e => e.CreatedAt).HasColumnName("created_at");
@@ -244,6 +250,12 @@ public class SessionEntity
     public int TargetedLoopCount { get; set; }
     public bool ClarificationIncomplete { get; set; }
     public int ClarificationRoundCount { get; set; }
+    public string? CouncilRunPhase { get; set; }
+    public DateTime? CouncilRunStartedAt { get; set; }
+    public DateTime? CouncilRunFirstProgressAt { get; set; }
+    public DateTime? CouncilRunLastProgressAt { get; set; }
+    public DateTime? CouncilRunCompletedAt { get; set; }
+    public string? CouncilRunFailedReason { get; set; }
     public Guid? ForkedFrom { get; set; }
     public Guid? ForkSnapshotId { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/backend/src/Agon.Infrastructure/Persistence/PostgreSQL/SessionRepository.cs
+++ b/backend/src/Agon.Infrastructure/Persistence/PostgreSQL/SessionRepository.cs
@@ -38,6 +38,12 @@ public sealed class SessionRepository : ISessionRepository
             TargetedLoopCount = sessionState.TargetedLoopCount,
             ClarificationIncomplete = sessionState.ClarificationIncomplete,
             ClarificationRoundCount = sessionState.ClarificationRoundCount,
+            CouncilRunPhase = sessionState.CouncilRunPhase,
+            CouncilRunStartedAt = sessionState.CouncilRunStartedAt?.UtcDateTime,
+            CouncilRunFirstProgressAt = sessionState.CouncilRunFirstProgressAt?.UtcDateTime,
+            CouncilRunLastProgressAt = sessionState.CouncilRunLastProgressAt?.UtcDateTime,
+            CouncilRunCompletedAt = sessionState.CouncilRunCompletedAt?.UtcDateTime,
+            CouncilRunFailedReason = sessionState.CouncilRunFailedReason,
             ForkedFrom = null, // TODO: Add to SessionState when fork support is added
             ForkSnapshotId = null, // TODO: Add to SessionState when fork support is added
             CreatedAt = sessionState.CreatedAt.UtcDateTime,
@@ -114,6 +120,12 @@ public sealed class SessionRepository : ISessionRepository
         entity.TargetedLoopCount = sessionState.TargetedLoopCount;
         entity.ClarificationIncomplete = sessionState.ClarificationIncomplete;
         entity.ClarificationRoundCount = sessionState.ClarificationRoundCount;
+        entity.CouncilRunPhase = sessionState.CouncilRunPhase;
+        entity.CouncilRunStartedAt = sessionState.CouncilRunStartedAt?.UtcDateTime;
+        entity.CouncilRunFirstProgressAt = sessionState.CouncilRunFirstProgressAt?.UtcDateTime;
+        entity.CouncilRunLastProgressAt = sessionState.CouncilRunLastProgressAt?.UtcDateTime;
+        entity.CouncilRunCompletedAt = sessionState.CouncilRunCompletedAt?.UtcDateTime;
+        entity.CouncilRunFailedReason = sessionState.CouncilRunFailedReason;
         entity.UpdatedAt = DateTime.UtcNow;
         sessionState.UpdatedAt = DateTime.SpecifyKind(entity.UpdatedAt, DateTimeKind.Utc);
 
@@ -176,6 +188,20 @@ public sealed class SessionRepository : ISessionRepository
         sessionState.TargetedLoopCount = entity.TargetedLoopCount;
         sessionState.ClarificationRoundCount = entity.ClarificationRoundCount;
         sessionState.ClarificationIncomplete = entity.ClarificationIncomplete;
+        sessionState.CouncilRunPhase = entity.CouncilRunPhase;
+        sessionState.CouncilRunStartedAt = entity.CouncilRunStartedAt.HasValue
+            ? DateTime.SpecifyKind(entity.CouncilRunStartedAt.Value, DateTimeKind.Utc)
+            : null;
+        sessionState.CouncilRunFirstProgressAt = entity.CouncilRunFirstProgressAt.HasValue
+            ? DateTime.SpecifyKind(entity.CouncilRunFirstProgressAt.Value, DateTimeKind.Utc)
+            : null;
+        sessionState.CouncilRunLastProgressAt = entity.CouncilRunLastProgressAt.HasValue
+            ? DateTime.SpecifyKind(entity.CouncilRunLastProgressAt.Value, DateTimeKind.Utc)
+            : null;
+        sessionState.CouncilRunCompletedAt = entity.CouncilRunCompletedAt.HasValue
+            ? DateTime.SpecifyKind(entity.CouncilRunCompletedAt.Value, DateTimeKind.Utc)
+            : null;
+        sessionState.CouncilRunFailedReason = entity.CouncilRunFailedReason;
         sessionState.CreatedAt = DateTime.SpecifyKind(entity.CreatedAt, DateTimeKind.Utc);
         sessionState.UpdatedAt = DateTime.SpecifyKind(entity.UpdatedAt, DateTimeKind.Utc);
 

--- a/backend/src/Agon.Infrastructure/Persistence/PostgreSQL/SessionRepository.cs
+++ b/backend/src/Agon.Infrastructure/Persistence/PostgreSQL/SessionRepository.cs
@@ -135,6 +135,39 @@ public sealed class SessionRepository : ISessionRepository
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task UpdateCouncilRunMetadataAsync(
+        SessionState sessionState,
+        CancellationToken cancellationToken = default)
+    {
+        var entity = await _dbContext.Sessions
+            .FirstOrDefaultAsync(s => s.Id == sessionState.SessionId, cancellationToken);
+
+        if (entity == null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot update council metadata for session {sessionState.SessionId}: session not found");
+        }
+
+        entity.CouncilRunPhase = sessionState.CouncilRunPhase;
+        entity.CouncilRunStartedAt = sessionState.CouncilRunStartedAt?.UtcDateTime;
+        entity.CouncilRunFirstProgressAt = sessionState.CouncilRunFirstProgressAt?.UtcDateTime;
+        entity.CouncilRunLastProgressAt = sessionState.CouncilRunLastProgressAt?.UtcDateTime;
+        entity.CouncilRunCompletedAt = sessionState.CouncilRunCompletedAt?.UtcDateTime;
+        entity.CouncilRunFailedReason = sessionState.CouncilRunFailedReason;
+        entity.UpdatedAt = DateTime.UtcNow;
+        sessionState.UpdatedAt = DateTime.SpecifyKind(entity.UpdatedAt, DateTimeKind.Utc);
+
+        _dbContext.Entry(entity).Property(e => e.CouncilRunPhase).IsModified = true;
+        _dbContext.Entry(entity).Property(e => e.CouncilRunStartedAt).IsModified = true;
+        _dbContext.Entry(entity).Property(e => e.CouncilRunFirstProgressAt).IsModified = true;
+        _dbContext.Entry(entity).Property(e => e.CouncilRunLastProgressAt).IsModified = true;
+        _dbContext.Entry(entity).Property(e => e.CouncilRunCompletedAt).IsModified = true;
+        _dbContext.Entry(entity).Property(e => e.CouncilRunFailedReason).IsModified = true;
+        _dbContext.Entry(entity).Property(e => e.UpdatedAt).IsModified = true;
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyList<SessionState>> ListByUserAsync(
         Guid userId,
         CancellationToken cancellationToken = default)

--- a/backend/tests/Agon.Application.Tests/Orchestration/AgentRunnerTests.cs
+++ b/backend/tests/Agon.Application.Tests/Orchestration/AgentRunnerTests.cs
@@ -223,7 +223,8 @@ public class AgentRunnerTests
                 MinQueryKeywordLength = 4,
                 MaxChunksPerAttachment = 10,
                 MaxChunkNoteChars = 120,
-                MaxFinalNotesPerAgent = 10
+                MaxFinalNotesPerAgent = 10,
+                EarlyExitMinNotesPerAgent = 10
             });
 
         var state = BuildSessionState();
@@ -329,6 +330,31 @@ public class AgentRunnerTests
 
         responses.Single(r => r.AgentId == AgentId.GptAgent).TimedOut.Should().BeTrue();
         stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public async Task RunAnalysisRoundAsync_AgentException_ReturnsFailedResponseAndContinues()
+    {
+        var healthy = StubAgent(AgentId.ClaudeAgent, SuccessResponse(AgentId.ClaudeAgent));
+        var throwingAgent = Substitute.For<ICouncilAgent>();
+        throwingAgent.AgentId.Returns(AgentId.GptAgent);
+        throwingAgent.ModelProvider.Returns("fake/model");
+        throwingAgent.RunAsync(Arg.Any<AgentContext>(), Arg.Any<CancellationToken>())
+            .Returns<Task<AgentResponse>>(_ => throw new InvalidOperationException("provider exploded"));
+
+        var runner = BuildRunner([healthy, throwingAgent], agentTimeoutSeconds: 1);
+        var state = BuildSessionState();
+
+        var responses = await runner.RunAnalysisRoundAsync(state, CancellationToken.None);
+
+        responses.Should().HaveCount(2);
+        var failed = responses.Single(r => r.AgentId == AgentId.GptAgent);
+        failed.Failed.Should().BeTrue();
+        failed.FailureReason.Should().Be("AGENT_EXECUTION_EXCEPTION");
+        failed.TimedOut.Should().BeFalse();
+        failed.Message.Should().BeEmpty();
+
+        responses.Single(r => r.AgentId == AgentId.ClaudeAgent).Failed.Should().BeFalse();
     }
 
     // ── Critique Round — cross-agent assignment ────────────────────────────────

--- a/backend/tests/Agon.Application.Tests/Orchestration/OrchestratorTests.cs
+++ b/backend/tests/Agon.Application.Tests/Orchestration/OrchestratorTests.cs
@@ -1,12 +1,14 @@
 using Agon.Application.Models;
 using Agon.Application.Orchestration;
 using Agon.Application.Services;
+using Agon.Application.Interfaces;
 using Agon.Domain.Agents;
 using Agon.Domain.Sessions;
 using Agon.Domain.TruthMap.Entities;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
+using System.Collections.Concurrent;
 using TruthMapModel = Agon.Domain.TruthMap.TruthMap;
 
 namespace Agon.Application.Tests.Orchestration;
@@ -157,6 +159,67 @@ public class OrchestratorTests
             state,
             "Refine the acceptance criteria",
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RunPostDeliveryFollowUpAsync_InvokeCouncilBackgroundFailure_PersistsCouncilFailedMessage()
+    {
+        var state = BuildState(SessionPhase.PostDelivery);
+        state.CurrentRound = 4;
+        state.UserMessages.Add(new UserMessage("invoke council", DateTimeOffset.UtcNow, 4));
+
+        var capturedMessages = new ConcurrentBag<AgentMessageRecord>();
+        var messageRepo = Substitute.For<IAgentMessageRepository>();
+        messageRepo.GetBySessionIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<AgentMessageRecord>>([]));
+        messageRepo.AddAsync(Arg.Any<AgentMessageRecord>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                capturedMessages.Add(call.ArgAt<AgentMessageRecord>(0));
+                return Task.CompletedTask;
+            });
+
+        var sessionService = Substitute.For<ISessionService>();
+        sessionService.AdvancePhaseAsync(Arg.Any<SessionState>(), Arg.Any<SessionPhase>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        sessionService.RecordRoundSnapshotAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        sessionService.GetAsync(state.SessionId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<SessionState?>(state));
+
+        var runner = Substitute.For<IAgentRunner>();
+        runner.RunPostDeliveryFollowUpAsync(Arg.Any<SessionState>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<Task<AgentResponse>>(_ => throw new InvalidOperationException("boom"));
+
+        var scopedProvider = Substitute.For<IServiceProvider>();
+        scopedProvider.GetService(typeof(IAgentRunner)).Returns(runner);
+        scopedProvider.GetService(typeof(ISessionService)).Returns(sessionService);
+        scopedProvider.GetService(typeof(IAgentMessageRepository)).Returns(messageRepo);
+        scopedProvider.GetService(typeof(ConversationHistoryService))
+            .Returns(new ConversationHistoryService(messageRepo));
+
+        var scope = Substitute.For<IServiceScope>();
+        scope.ServiceProvider.Returns(scopedProvider);
+
+        var scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(scope);
+
+        var orchestrator = new Orchestrator(
+            runner,
+            sessionService,
+            scopeFactory,
+            DefaultPolicy());
+
+        await orchestrator.RunPostDeliveryFollowUpAsync(state, "invoke council", CancellationToken.None);
+
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(2);
+        while (DateTimeOffset.UtcNow < deadline
+               && !capturedMessages.Any(m => m.AgentId == "council_failed"))
+        {
+            await Task.Delay(25);
+        }
+
+        capturedMessages.Any(m => m.AgentId == "council_failed").Should().BeTrue();
     }
 
     // ── RunFullDebateChainAsync ──────────────────────────────────────────────

--- a/backend/tests/Agon.Application.Tests/Services/ConversationHistoryServiceTests.cs
+++ b/backend/tests/Agon.Application.Tests/Services/ConversationHistoryServiceTests.cs
@@ -4,6 +4,7 @@ using Agon.Application.Services;
 using Agon.Domain.Sessions;
 using FluentAssertions;
 using NSubstitute;
+using System.Diagnostics.Metrics;
 using TruthMapModel = Agon.Domain.TruthMap.TruthMap;
 
 namespace Agon.Application.Tests.Services;
@@ -124,7 +125,7 @@ public class ConversationHistoryServiceTests
             CancellationToken.None);
 
         // Assert
-        await sessionRepo.Received(1).UpdateAsync(
+        await sessionRepo.Received(1).UpdateCouncilRunMetadataAsync(
             Arg.Is<SessionState>(s =>
                 s.CouncilRunPhase == "analysis"
                 && s.CouncilRunStartedAt.HasValue
@@ -132,16 +133,18 @@ public class ConversationHistoryServiceTests
                 && s.CouncilRunLastProgressAt.HasValue
                 && s.CouncilRunFailedReason == null),
             Arg.Any<CancellationToken>());
+
+        await sessionRepo.DidNotReceive().UpdateAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task StoreMessageAsync_CouncilFailed_PersistsFailureReason()
+    public async Task StoreMessageAsync_CouncilFailed_PersistsFailureReasonWithoutChangingSessionStatus()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
         var sessionRepo = Substitute.For<ISessionRepository>();
         var state = SessionState.Create(sessionId, Guid.NewGuid(), "idea", 50, false, TruthMapModel.Empty(sessionId));
-        state.Status = SessionStatus.Active;
+        state.Status = SessionStatus.Complete;
         sessionRepo.GetAsync(sessionId, Arg.Any<CancellationToken>())
             .Returns(state);
 
@@ -156,12 +159,139 @@ public class ConversationHistoryServiceTests
             CancellationToken.None);
 
         // Assert
-        await sessionRepo.Received(1).UpdateAsync(
+        await sessionRepo.Received(1).UpdateCouncilRunMetadataAsync(
             Arg.Is<SessionState>(s =>
-                s.Status == SessionStatus.CompleteWithGaps
+                s.Status == SessionStatus.Complete
                 && s.CouncilRunPhase == "failed"
                 && s.CouncilRunCompletedAt.HasValue
                 && s.CouncilRunFailedReason == "COUNCIL_BACKGROUND_FAILURE"),
             Arg.Any<CancellationToken>());
+
+        await sessionRepo.DidNotReceive().UpdateAsync(Arg.Any<SessionState>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StoreMessageAsync_CouncilRunning_ResetsRunMetadataForFreshRetry()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var sessionRepo = Substitute.For<ISessionRepository>();
+        var state = SessionState.Create(sessionId, Guid.NewGuid(), "idea", 50, false, TruthMapModel.Empty(sessionId));
+        var oldStart = DateTimeOffset.UtcNow.AddMinutes(-15);
+        state.CouncilRunPhase = "failed";
+        state.CouncilRunStartedAt = oldStart;
+        state.CouncilRunFirstProgressAt = DateTimeOffset.UtcNow.AddMinutes(-14);
+        state.CouncilRunLastProgressAt = DateTimeOffset.UtcNow.AddMinutes(-13);
+        state.CouncilRunCompletedAt = DateTimeOffset.UtcNow.AddMinutes(-12);
+        state.CouncilRunFailedReason = "OLD_REASON";
+        sessionRepo.GetAsync(sessionId, Arg.Any<CancellationToken>()).Returns(state);
+
+        var service = new ConversationHistoryService(_mockMessageRepo, sessionRepo);
+
+        // Act
+        await service.StoreMessageAsync(
+            sessionId,
+            "council_running",
+            "Council invoked — running in background.",
+            round: 3,
+            CancellationToken.None);
+
+        // Assert
+        await sessionRepo.Received(1).UpdateCouncilRunMetadataAsync(
+            Arg.Is<SessionState>(s =>
+                s.CouncilRunPhase == "queued"
+                && s.CouncilRunStartedAt.HasValue
+                && s.CouncilRunStartedAt.Value > oldStart
+                && s.CouncilRunFirstProgressAt == null
+                && s.CouncilRunLastProgressAt.HasValue
+                && s.CouncilRunCompletedAt == null
+                && s.CouncilRunFailedReason == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StoreMessageAsync_CouncilProgress_ClearsStaleTerminalFields()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var sessionRepo = Substitute.For<ISessionRepository>();
+        var state = SessionState.Create(sessionId, Guid.NewGuid(), "idea", 50, false, TruthMapModel.Empty(sessionId));
+        state.CouncilRunPhase = "failed";
+        state.CouncilRunStartedAt = DateTimeOffset.UtcNow.AddMinutes(-10);
+        state.CouncilRunCompletedAt = DateTimeOffset.UtcNow.AddMinutes(-9);
+        state.CouncilRunFailedReason = "COUNCIL_BACKGROUND_FAILURE";
+        sessionRepo.GetAsync(sessionId, Arg.Any<CancellationToken>()).Returns(state);
+
+        var service = new ConversationHistoryService(_mockMessageRepo, sessionRepo);
+
+        // Act
+        await service.StoreMessageAsync(
+            sessionId,
+            "council_progress",
+            "Stage: analysis (starting)",
+            round: 4,
+            CancellationToken.None);
+
+        // Assert
+        await sessionRepo.Received(1).UpdateCouncilRunMetadataAsync(
+            Arg.Is<SessionState>(s =>
+                s.CouncilRunPhase == "analysis"
+                && s.CouncilRunCompletedAt == null
+                && s.CouncilRunFailedReason == null
+                && s.CouncilRunFirstProgressAt.HasValue),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StoreMessageAsync_StageDurationMetric_UsesStageWindowInsteadOfTransitionGap()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var sessionRepo = Substitute.For<ISessionRepository>();
+        var state = SessionState.Create(sessionId, Guid.NewGuid(), "idea", 50, false, TruthMapModel.Empty(sessionId));
+        sessionRepo.GetAsync(sessionId, Arg.Any<CancellationToken>()).Returns(state);
+
+        var capturedAnalysisDurations = new List<double>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, meterListener) =>
+        {
+            if (instrument.Meter.Name == "Agon.Application.CouncilRuns"
+                && instrument.Name == "agon_council_stage_duration_ms")
+            {
+                meterListener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((_, measurement, tags, _) =>
+        {
+            string? stage = null;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "stage")
+                {
+                    stage = tag.Value?.ToString();
+                    break;
+                }
+            }
+
+            if (string.Equals(stage, "analysis", StringComparison.OrdinalIgnoreCase))
+            {
+                capturedAnalysisDurations.Add(measurement);
+            }
+        });
+        listener.Start();
+
+        var service = new ConversationHistoryService(_mockMessageRepo, sessionRepo);
+
+        // Act
+        await service.StoreMessageAsync(sessionId, "council_running", "Council invoked", 1, CancellationToken.None);
+        await service.StoreMessageAsync(sessionId, "council_progress", "Stage: analysis (starting)", 1, CancellationToken.None);
+        await Task.Delay(40);
+        await service.StoreMessageAsync(sessionId, "council_progress", "Stage: analysis (completed)", 1, CancellationToken.None);
+        await Task.Delay(2);
+        await service.StoreMessageAsync(sessionId, "council_progress", "Stage: critique (starting)", 1, CancellationToken.None);
+
+        // Assert
+        capturedAnalysisDurations.Should().NotBeEmpty();
+        capturedAnalysisDurations.Max().Should().BeGreaterThanOrEqualTo(30d);
     }
 }

--- a/backend/tests/Agon.Application.Tests/Services/ConversationHistoryServiceTests.cs
+++ b/backend/tests/Agon.Application.Tests/Services/ConversationHistoryServiceTests.cs
@@ -1,8 +1,10 @@
 using Agon.Application.Interfaces;
 using Agon.Application.Models;
 using Agon.Application.Services;
+using Agon.Domain.Sessions;
 using FluentAssertions;
 using NSubstitute;
+using TruthMapModel = Agon.Domain.TruthMap.TruthMap;
 
 namespace Agon.Application.Tests.Services;
 
@@ -99,5 +101,67 @@ public class ConversationHistoryServiceTests
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(async () =>
             await _service.StoreMessageAsync(sessionId, null!, "message", 1, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task StoreMessageAsync_CouncilProgress_PersistsRunMetadata()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var sessionRepo = Substitute.For<ISessionRepository>();
+        var state = SessionState.Create(sessionId, Guid.NewGuid(), "idea", 50, false, TruthMapModel.Empty(sessionId));
+        sessionRepo.GetAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns(state);
+
+        var service = new ConversationHistoryService(_mockMessageRepo, sessionRepo);
+
+        // Act
+        await service.StoreMessageAsync(
+            sessionId,
+            "council_progress",
+            "Stage: analysis (running council agents)",
+            round: 2,
+            CancellationToken.None);
+
+        // Assert
+        await sessionRepo.Received(1).UpdateAsync(
+            Arg.Is<SessionState>(s =>
+                s.CouncilRunPhase == "analysis"
+                && s.CouncilRunStartedAt.HasValue
+                && s.CouncilRunFirstProgressAt.HasValue
+                && s.CouncilRunLastProgressAt.HasValue
+                && s.CouncilRunFailedReason == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task StoreMessageAsync_CouncilFailed_PersistsFailureReason()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var sessionRepo = Substitute.For<ISessionRepository>();
+        var state = SessionState.Create(sessionId, Guid.NewGuid(), "idea", 50, false, TruthMapModel.Empty(sessionId));
+        state.Status = SessionStatus.Active;
+        sessionRepo.GetAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns(state);
+
+        var service = new ConversationHistoryService(_mockMessageRepo, sessionRepo);
+
+        // Act
+        await service.StoreMessageAsync(
+            sessionId,
+            "council_failed",
+            "Council failed. ReasonCode=COUNCIL_BACKGROUND_FAILURE",
+            round: 2,
+            CancellationToken.None);
+
+        // Assert
+        await sessionRepo.Received(1).UpdateAsync(
+            Arg.Is<SessionState>(s =>
+                s.Status == SessionStatus.CompleteWithGaps
+                && s.CouncilRunPhase == "failed"
+                && s.CouncilRunCompletedAt.HasValue
+                && s.CouncilRunFailedReason == "COUNCIL_BACKGROUND_FAILURE"),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/backend/tests/Agon.Integration.Tests/ProgramIntegrationTests.cs
+++ b/backend/tests/Agon.Integration.Tests/ProgramIntegrationTests.cs
@@ -152,6 +152,9 @@ public class ProgramIntegrationTests : IClassFixture<AgonWebApplicationFactory>
             builder.UseSetting("AttachmentProcessing:ChunkLoop:MaxChunksPerAttachment", "12");
             builder.UseSetting("AttachmentProcessing:ChunkLoop:MaxChunkNoteChars", "900");
             builder.UseSetting("AttachmentProcessing:ChunkLoop:MaxFinalNotesPerAgent", "6");
+            builder.UseSetting("AttachmentProcessing:ChunkLoop:MaxPreludePasses", "7");
+            builder.UseSetting("AttachmentProcessing:ChunkLoop:MaxChunkBudgetChars", "120000");
+            builder.UseSetting("AttachmentProcessing:ChunkLoop:EarlyExitMinNotesPerAgent", "5");
         });
 
         using var scope = factory.Services.CreateScope();
@@ -170,6 +173,9 @@ public class ProgramIntegrationTests : IClassFixture<AgonWebApplicationFactory>
         options.MaxChunksPerAttachment.Should().Be(12);
         options.MaxChunkNoteChars.Should().Be(900);
         options.MaxFinalNotesPerAgent.Should().Be(6);
+        options.MaxPreludePasses.Should().Be(7);
+        options.MaxChunkBudgetChars.Should().Be(120000);
+        options.EarlyExitMinNotesPerAgent.Should().Be(5);
     }
 
     [Fact]

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -8,6 +8,12 @@ export interface SessionResponse {
   phase: SessionPhase;
   createdAt: string;
   updatedAt: string;
+  councilRunPhase?: string | null;
+  councilRunStartedAt?: string | null;
+  councilRunFirstProgressAt?: string | null;
+  councilRunLastProgressAt?: string | null;
+  councilRunCompletedAt?: string | null;
+  councilRunFailedReason?: string | null;
   convergence?: ConvergenceScore;
   currentRound?: number;
   tokensUsed?: number;

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -1215,8 +1215,8 @@ export default class Shell extends Command {
     const watchStartedAt = Date.now();
     let lastProgressAt = watchStartedAt;
     let consecutiveFailures = 0;
-    const maxWatchDurationMs = getWatchDurationMsFromEnv('AGON_COUNCIL_WATCH_MAX_MINUTES', 15);
-    const maxIdleDurationMs = getWatchDurationMsFromEnv('AGON_WATCH_MAX_IDLE_MINUTES', 8);
+    let pollDelayMs = 1500;
+    const maxWatchDurationMs = getOptionalWatchDurationMsFromEnv('AGON_COUNCIL_WATCH_MAX_MINUTES');
     const maxConsecutiveFailures = 5;
     const acknowledgedAtMs = acknowledgedAt
       ? new Date(acknowledgedAt).getTime()
@@ -1247,16 +1247,22 @@ export default class Shell extends Command {
           return;
         }
 
-        if (Date.now() - watchStartedAt > maxWatchDurationMs) {
+        if (maxWatchDurationMs !== null && Date.now() - watchStartedAt > maxWatchDurationMs) {
           progressSpinner.stop();
           this.log(chalk.yellow('Council watch timed out. Council may still be running in the background.'));
           this.log(chalk.dim('Type any follow-up to check for results, or run /status.'));
           return;
         }
 
+        let session;
         let messages;
         try {
-          messages = await this.apiClient.getMessages(sessionId);
+          [session, messages] = await Promise.all([
+            this.apiClient.getSession(sessionId),
+            this.apiClient.getMessages(sessionId)
+          ]);
+          await this.sessionManager.saveSession(session);
+          shimmerBase = `Council is analyzing... (${this.formatPhaseForDisplay(session.phase)})`;
           consecutiveFailures = 0;
         } catch (error) {
           consecutiveFailures += 1;
@@ -1272,6 +1278,17 @@ export default class Shell extends Command {
           continue;
         }
 
+        const progressMessages = messages
+          .filter(m => {
+            const agent = m.agentId.toLowerCase();
+            const isProgress = agent === 'council_progress'
+              || agent === 'council_failed'
+              || agent === 'council_complete';
+            const isNew = new Date(m.createdAt).getTime() >= acknowledgedAtMs;
+            return isProgress && isNew;
+          })
+          .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+
         // Only surface messages that were created after the council acknowledgement.
         // Excludes system/user/acknowledgement agents so only substantive analysis shows.
         const councilMessages = messages
@@ -1280,6 +1297,9 @@ export default class Shell extends Command {
             const isSubstantive = agent !== 'moderator'
               && agent !== 'user'
               && agent !== 'council_running'
+              && agent !== 'council_progress'
+              && agent !== 'council_failed'
+              && agent !== 'council_complete'
               && agent !== 'post_delivery_assistant';
             const isNew = new Date(m.createdAt).getTime() >= acknowledgedAtMs;
             return isSubstantive && isNew;
@@ -1295,6 +1315,33 @@ export default class Shell extends Command {
         };
 
         let foundSynthesizer = false;
+        let foundTerminalFailure = false;
+        let sawNewProgress = false;
+        for (const msg of progressMessages) {
+          const key = `${msg.agentId}:${msg.round}:${msg.createdAt}:${msg.message.length}`;
+          if (seenMessageKeys.has(key)) {
+            continue;
+          }
+
+          seenMessageKeys.add(key);
+          lastProgressAt = Date.now();
+          thinkingStartedAt = Date.now();
+          sawNewProgress = true;
+
+          stopSpinnerForOutput();
+          if (msg.agentId === 'council_progress') {
+            this.log(chalk.dim(`⏱️  ${msg.message}`));
+            this.log('');
+          } else if (msg.agentId === 'council_failed') {
+            this.log(chalk.red(msg.message));
+            this.log('');
+            foundTerminalFailure = true;
+          } else if (msg.agentId === 'council_complete') {
+            this.log(chalk.green(msg.message));
+            this.log('');
+          }
+        }
+
         for (const msg of councilMessages) {
           const key = `${msg.agentId}:${msg.round}:${msg.createdAt}:${msg.message.length}`;
           if (seenMessageKeys.has(key)) {
@@ -1304,6 +1351,7 @@ export default class Shell extends Command {
           seenMessageKeys.add(key);
           lastProgressAt = Date.now();
           thinkingStartedAt = Date.now();
+          sawNewProgress = true;
 
           stopSpinnerForOutput();
           this.log('━'.repeat(60));
@@ -1328,10 +1376,9 @@ export default class Shell extends Command {
           return;
         }
 
-        if (Date.now() - lastProgressAt > maxIdleDurationMs) {
-          progressSpinner.stop();
-          this.log(chalk.yellow('No council progress detected for a while. Stopping live watch.'));
-          this.log(chalk.dim('Type any follow-up to check for results, or run /status.'));
+        if (foundTerminalFailure) {
+          this.log(chalk.yellow('Council stopped due to a terminal failure.'));
+          this.log(chalk.dim("Retry with 'invoke council' after correcting provider/runtime configuration if needed."));
           return;
         }
 
@@ -1341,7 +1388,12 @@ export default class Shell extends Command {
           shimmerBase = 'Council is analyzing...';
         }
 
-        await new Promise(resolve => setTimeout(resolve, 2500));
+        pollDelayMs = getAdaptiveCouncilPollDelayMs({
+          currentDelayMs: pollDelayMs,
+          sawNewProgress,
+          idleMs: Date.now() - lastProgressAt
+        });
+        await new Promise(resolve => setTimeout(resolve, pollDelayMs));
       }
     } finally {
       clearInterval(shimmerInterval);
@@ -1362,6 +1414,47 @@ function getWatchDurationMsFromEnv(envKey: string, fallbackMinutes: number): num
   }
 
   return parsed * 60_000;
+}
+
+function getOptionalWatchDurationMsFromEnv(envKey: string): number | null {
+  const raw = process.env[envKey];
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed * 60_000;
+}
+
+function getAdaptiveCouncilPollDelayMs(params: {
+  currentDelayMs: number;
+  sawNewProgress: boolean;
+  idleMs: number;
+}): number {
+  const minDelayMs = 1200;
+  const maxDelayMs = 9000;
+
+  if (params.sawNewProgress) {
+    return minDelayMs;
+  }
+
+  if (params.idleMs >= 120_000) {
+    return Math.min(maxDelayMs, Math.max(params.currentDelayMs, 8000));
+  }
+
+  if (params.idleMs >= 60_000) {
+    return Math.min(maxDelayMs, Math.max(params.currentDelayMs, 6000));
+  }
+
+  if (params.idleMs >= 30_000) {
+    return Math.min(maxDelayMs, Math.max(params.currentDelayMs, 4000));
+  }
+
+  return Math.min(maxDelayMs, Math.max(minDelayMs, params.currentDelayMs + 500));
 }
 
 function isWordCharacter(char: string): boolean {

--- a/cli/src/commands/shell.ts
+++ b/cli/src/commands/shell.ts
@@ -1316,6 +1316,7 @@ export default class Shell extends Command {
 
         let foundSynthesizer = false;
         let foundTerminalFailure = false;
+        let foundTerminalComplete = false;
         let sawNewProgress = false;
         for (const msg of progressMessages) {
           const key = `${msg.agentId}:${msg.round}:${msg.createdAt}:${msg.message.length}`;
@@ -1339,6 +1340,7 @@ export default class Shell extends Command {
           } else if (msg.agentId === 'council_complete') {
             this.log(chalk.green(msg.message));
             this.log('');
+            foundTerminalComplete = true;
           }
         }
 
@@ -1376,7 +1378,25 @@ export default class Shell extends Command {
           return;
         }
 
+        const councilRunPhase = (session.councilRunPhase ?? '').toLowerCase();
+        if (foundTerminalComplete || councilRunPhase === 'completed') {
+          this.log(chalk.green('✓ Council analysis complete.'));
+          this.log('');
+          this.log('Next steps:');
+          this.log('  • Continue in this shell: type your next message');
+          this.log('  • Add a file: paste/drag a local file path into the input box');
+          this.log('  • Start a new session: /new');
+          this.log('  • Exit shell: /exit');
+          return;
+        }
+
         if (foundTerminalFailure) {
+          this.log(chalk.yellow('Council stopped due to a terminal failure.'));
+          this.log(chalk.dim("Retry with 'invoke council' after correcting provider/runtime configuration if needed."));
+          return;
+        }
+
+        if (councilRunPhase === 'failed') {
           this.log(chalk.yellow('Council stopped due to a terminal failure.'));
           this.log(chalk.dim("Retry with 'invoke council' after correcting provider/runtime configuration if needed."));
           return;

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -125,6 +125,27 @@ export default class Status extends Command {
     this.log(`Updated:     ${updatedDate.toLocaleString()}`);
     this.log('');
 
+    if (session.councilRunPhase) {
+      this.log('Council Run:');
+      this.log(`  Phase:            ${session.councilRunPhase}`);
+      if (session.councilRunStartedAt) {
+        this.log(`  Started:          ${new Date(session.councilRunStartedAt).toLocaleString()}`);
+      }
+      if (session.councilRunFirstProgressAt) {
+        this.log(`  First Progress:   ${new Date(session.councilRunFirstProgressAt).toLocaleString()}`);
+      }
+      if (session.councilRunLastProgressAt) {
+        this.log(`  Last Progress:    ${new Date(session.councilRunLastProgressAt).toLocaleString()}`);
+      }
+      if (session.councilRunCompletedAt) {
+        this.log(`  Completed:        ${new Date(session.councilRunCompletedAt).toLocaleString()}`);
+      }
+      if (session.councilRunFailedReason) {
+        this.log(`  Failed Reason:    ${session.councilRunFailedReason}`);
+      }
+      this.log('');
+    }
+
     // Round info (if in debate)
     if (session.currentRound !== undefined) {
       this.log(`Current Round: ${session.currentRound}`);

--- a/infrastructure/COUNCIL-RELIABILITY-ROLLOUT.md
+++ b/infrastructure/COUNCIL-RELIABILITY-ROLLOUT.md
@@ -1,0 +1,47 @@
+# Council Reliability Rollout (Epic #558)
+
+## Target State
+
+- Council runs emit explicit stage progress: `analysis`, `chunking`, `critique`, `synthesis`, `completed`, `failed`.
+- CLI council watch remains active until terminal completion/failure or explicit user interrupt.
+- Agent-level failures are isolated; one agent failure does not terminate the whole run.
+- Large-document chunk prelude work is capped to control latency and token cost.
+
+## SLOs
+
+- `CouncilFirstProgressP95 <= 90s`
+- `CouncilCompletionSuccessRate >= 98%` (excluding explicit user interrupts)
+- `CouncilSilentFailureRate = 0%` (every failure must publish `council_failed`)
+- `CouncilMedianDurationLargeDoc <= baseline * 0.75` after optimization rollout
+
+## Required Metrics
+
+- `council_invoked_total`
+- `council_progress_stage_total{stage=...}`
+- `council_completed_total`
+- `council_failed_total{reason_code=...}`
+- `council_stage_duration_ms{stage=...}`
+- `council_token_usage_total{provider,model}`
+- `council_chunk_prelude_pass_total`
+
+## Azure Guardrails
+
+- Use Application Insights + Log Analytics for run telemetry and stage timelines.
+- Add Azure Monitor alerts for:
+  - `council_failed_total` spike
+  - missing `council_progress` for active runs
+  - elevated duration and token anomalies
+- Route alerts to on-call channel with run/session identifiers.
+
+## Rollout Plan
+
+1. Deploy with feature flag enabled in `dev` only.
+2. Validate SLO telemetry and failure reason-code quality for 48h.
+3. Enable in `stage` with canary cohort.
+4. Enable in `prod` gradually (10% -> 50% -> 100%).
+
+## Rollback
+
+- Disable council reliability feature flag.
+- Revert chunk-loop cap changes if token/quality regression is observed.
+- Keep `council_failed` terminal messaging enabled for operator visibility.


### PR DESCRIPTION
## Summary
Implements the remaining reliability, observability, and cost-control gaps for Epic #558 and associated P0 tickets.

## What changed
- Keep council watch alive until terminal state; add adaptive polling backoff in CLI council watch.
- Persist explicit council run metadata on sessions:
  - `council_run_phase`
  - `council_run_started_at`
  - `council_run_first_progress_at`
  - `council_run_last_progress_at`
  - `council_run_completed_at`
  - `council_run_failed_reason`
- Added migration: `AddCouncilRunMetadata`.
- Added council lifecycle metrics (`started`, `first_progress`, `completed`, `failed`, stage and run duration histograms).
- Strengthened chunk-loop map/reduce cost controls:
  - max prelude passes
  - max chunk budget chars
  - early-exit threshold once sufficient notes are gathered
- Extended API/CLI status surfaces to expose council run metadata.
- Added/updated tests in application + integration + CLI areas.
- Added rollout guide: `infrastructure/COUNCIL-RELIABILITY-ROLLOUT.md`.

## Validation
- `dotnet test backend/tests/Agon.Application.Tests/Agon.Application.Tests.csproj --verbosity minimal`
- `dotnet test backend/tests/Agon.Integration.Tests/Agon.Integration.Tests.csproj --verbosity minimal`
- `npm --prefix cli test -- --run`

## Notes
- Epic and P0 child tickets (#558, #559, #560, #561, #562) have been closed as completed.
