### PR TITLE
fix(auth): use auth endpoint for login token verification

### DIFF
--- a/.changeset/short-walls-turn.md
+++ b/.changeset/short-walls-turn.md
@@ -1,0 +1,7 @@
+---
+"@agon_agents/cli": patch
+---
+
+Fix `agon login` token verification to use an auth-only endpoint (`/auth/verify`) instead of `/sessions`, so login succeeds when authentication is valid even if session listing is unavailable.
+
+Also keep `/auth/status` anonymously accessible even when minimum CLI version enforcement is enabled, preserving auth discovery behavior.

--- a/backend/src/Agon.Api/Middleware/MinimumCliVersionMiddleware.cs
+++ b/backend/src/Agon.Api/Middleware/MinimumCliVersionMiddleware.cs
@@ -90,6 +90,11 @@ public sealed class MinimumCliVersionMiddleware
             return true;
         }
 
+        if (path.Equals("/auth/status", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (path.StartsWith("/hubs", StringComparison.OrdinalIgnoreCase))
         {
             return true;

--- a/backend/src/Agon.Api/Program.cs
+++ b/backend/src/Agon.Api/Program.cs
@@ -722,6 +722,19 @@ var authStatusPayload = AuthStatusResponseFactory.Create(
     tenantIdHint: authTenantId,
     interactiveClientId: authInteractiveClientId);
 app.MapGet("/auth/status", () => Results.Ok(authStatusPayload)).AllowAnonymous();
+app.MapGet("/auth/verify", (ClaimsPrincipal user) =>
+{
+    var claimValue =
+        user.FindFirstValue("oid")
+        ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+        ?? user.FindFirstValue("sub");
+
+    return Results.Ok(new
+    {
+        authenticated = user.Identity?.IsAuthenticated ?? false,
+        userId = claimValue
+    });
+});
 var controllers = app.MapControllers();
 if (authEnabled)
 {

--- a/backend/tests/Agon.Integration.Tests/AuthStatusIntegrationTests.cs
+++ b/backend/tests/Agon.Integration.Tests/AuthStatusIntegrationTests.cs
@@ -1,6 +1,11 @@
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Agon.Integration.Tests;
 
@@ -13,10 +18,13 @@ namespace Agon.Integration.Tests;
 /// </summary>
 public class AuthStatusIntegrationTests : IClassFixture<AgonWebApplicationFactory>
 {
+    private const string RequiredVersion = "999.0.0";
     private readonly HttpClient _client;
+    private readonly AgonWebApplicationFactory _factory;
 
     public AuthStatusIntegrationTests(AgonWebApplicationFactory factory)
     {
+        _factory = factory;
         _client = factory.CreateClient();
     }
 
@@ -93,6 +101,66 @@ public class AuthStatusIntegrationTests : IClassFixture<AgonWebApplicationFactor
         authorityProperty.ValueKind.Should().Be(JsonValueKind.Null);
         audienceProperty.ValueKind.Should().Be(JsonValueKind.Null);
         interactiveClientIdProperty.ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact]
+    public async Task GET_Auth_Status_Bypasses_Minimum_Cli_Version_Enforcement()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Agon:MinCliVersion"] = RequiredVersion
+                });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync("/auth/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GET_Auth_Verify_Returns_200_For_Authenticated_Request()
+    {
+        using var factory = CreateAuthenticatedFactory();
+        using var client = CreateUserClient(factory, Guid.NewGuid());
+
+        var response = await client.GetAsync("/auth/verify");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private WebApplicationFactory<Program> CreateAuthenticatedFactory()
+    {
+        return _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Authentication:Enabled"] = "true"
+                });
+            });
+
+            builder.ConfigureServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+            });
+        });
+    }
+
+    private static HttpClient CreateUserClient(WebApplicationFactory<Program> factory, Guid userId)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, userId.ToString());
+        return client;
     }
 
 }

--- a/cli/src/api/agon-client.ts
+++ b/cli/src/api/agon-client.ts
@@ -35,6 +35,11 @@ export interface AuthStatusResponse {
   interactiveClientId?: string;
 }
 
+interface AuthVerifyResponse {
+  authenticated: boolean;
+  userId?: string;
+}
+
 export class AgonAPIClient {
   private readonly client: AxiosInstance;
   private readonly maxRetries = 2;
@@ -344,6 +349,14 @@ export class AgonAPIClient {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Verify that the supplied bearer token is accepted by the backend.
+   */
+  async verifyAuthToken(): Promise<boolean> {
+    const response = await this.client.get<AuthVerifyResponse>('/auth/verify');
+    return response.data?.authenticated === true;
   }
 
   // Helper methods

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -238,7 +238,10 @@ export default class Login extends Command {
           this.config.pjson.version ?? '0.0.0',
           token
         );
-        await testClient.listSessions();
+        const isAuthenticated = await testClient.verifyAuthToken();
+        if (!isAuthenticated) {
+          throw new Error('Authentication required. Your request was rejected by the backend.');
+        }
       }
       spinner.succeed('Token accepted');
     } catch (error) {

--- a/cli/test/api/agon-client.test.ts
+++ b/cli/test/api/agon-client.test.ts
@@ -404,6 +404,29 @@ describe('AgonAPIClient', () => {
     });
   });
 
+  describe('verifyAuthToken', () => {
+    it('calls auth verify endpoint and returns true when authenticated', async () => {
+      (mockAxios.get as any).mockResolvedValue({
+        data: { authenticated: true, userId: 'user-123' }
+      });
+
+      const result = await client.verifyAuthToken();
+
+      expect(mockAxios.get).toHaveBeenCalledWith('/auth/verify');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when backend reports unauthenticated', async () => {
+      (mockAxios.get as any).mockResolvedValue({
+        data: { authenticated: false }
+      });
+
+      const result = await client.verifyAuthToken();
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('auth token constructor parameter', () => {
     it('uses explicit authToken parameter over env var', () => {
       process.env.AGON_AUTH_TOKEN = 'env-token';


### PR DESCRIPTION
## Summary
- bypass minimum CLI version enforcement for `/auth/status` so anonymous auth discovery remains available
- add authenticated `GET /auth/verify` endpoint for token acceptance checks
- update CLI login verification to call `/auth/verify` instead of `/sessions`
- add integration and unit tests for the new auth verification behavior

## Validation
- `DOTNET_CLI_HOME=/tmp dotnet test backend/tests/Agon.Integration.Tests/Agon.Integration.Tests.csproj --filter AuthStatusIntegrationTests --verbosity minimal`
- `npm test -- agon-client.test.ts`