### PR TITLE
fix(api): make trial audit persistence non-blocking for session creation

### DIFF
--- a/backend/src/Agon.Api/Services/TrialAccessService.cs
+++ b/backend/src/Agon.Api/Services/TrialAccessService.cs
@@ -579,8 +579,22 @@ public sealed class TrialAccessService
             OccurredAt = DateTimeOffset.UtcNow
         };
 
-        await _dbContext.TrialAuditEvents.AddAsync(entity, cancellationToken);
-        await _dbContext.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _dbContext.TrialAuditEvents.AddAsync(entity, cancellationToken);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Audit logging is best-effort and must never block session creation or access checks.
+            _dbContext.Entry(entity).State = EntityState.Detached;
+
+            _logger.LogError(
+                ex,
+                "Trial audit persistence failed for action {Action} with reason code {ReasonCode}.",
+                action,
+                reasonCode);
+        }
     }
 
     private static HashSet<string> ResolveRequiredTesterGroupIds(

--- a/backend/tests/Agon.Integration.Tests/TrialAccessIntegrationTests.cs
+++ b/backend/tests/Agon.Integration.Tests/TrialAccessIntegrationTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -76,6 +77,21 @@ public sealed class TrialAccessIntegrationTests : IClassFixture<AgonWebApplicati
             .ToList();
 
         allowAudit.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateSession_Should_Allow_Allowlisted_User_When_TrialAuditPersistence_Fails()
+    {
+        using var factory = CreateTrialEnabledFactory(simulateAuditPersistenceFailure: true);
+        var userClient = CreateUserClient(factory, Guid.NewGuid(), [RequiredTesterGroupId]);
+
+        var response = await userClient.PostAsJsonAsync("/sessions", new
+        {
+            idea = "Trial audit persistence failure should not block session creation.",
+            frictionLevel = 50
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
     }
 
     [Fact]
@@ -426,7 +442,8 @@ public sealed class TrialAccessIntegrationTests : IClassFixture<AgonWebApplicati
         IReadOnlyList<string>? requiredTesterGroupIds = null,
         string? requiredTesterGroupIdsCsv = null,
         IReadOnlyList<string>? adminBypassGroupIds = null,
-        string? adminBypassGroupIdsCsv = null)
+        string? adminBypassGroupIdsCsv = null,
+        bool simulateAuditPersistenceFailure = false)
     {
         var effectiveRequiredTesterGroupIds = requiredTesterGroupIds ?? [RequiredTesterGroupId];
         var effectiveAdminBypassGroupIds = adminBypassGroupIds ?? Array.Empty<string>();
@@ -507,6 +524,12 @@ public sealed class TrialAccessIntegrationTests : IClassFixture<AgonWebApplicati
                 });
                 services.RemoveAll<TrialRequestRateLimiter>();
                 services.AddSingleton<TrialRequestRateLimiter>();
+
+                if (simulateAuditPersistenceFailure)
+                {
+                    services.RemoveAll<AgonDbContext>();
+                    services.AddScoped<AgonDbContext, ThrowOnTrialAuditSaveAgonDbContext>();
+                }
 
                 services
                     .AddAuthentication(options =>
@@ -597,5 +620,23 @@ public sealed class TrialAccessIntegrationTests : IClassFixture<AgonWebApplicati
     {
         using var payload = JsonDocument.Parse(await createResponse.Content.ReadAsStringAsync());
         return payload.RootElement.GetProperty("id").GetGuid();
+    }
+}
+
+internal sealed class ThrowOnTrialAuditSaveAgonDbContext : AgonDbContext
+{
+    public ThrowOnTrialAuditSaveAgonDbContext(DbContextOptions<AgonDbContext> options)
+        : base(options)
+    {
+    }
+
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        if (ChangeTracker.Entries<TrialAuditEventEntity>().Any(entry => entry.State == EntityState.Added))
+        {
+            throw new DbUpdateException("Simulated failure while persisting trial audit events.");
+        }
+
+        return base.SaveChangesAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- make `TrialAccessService.WriteAuditEventAsync` best-effort so audit persistence failures do not fail `POST /sessions`
- detach the failed `TrialAuditEventEntity` from the EF change tracker to prevent poisoning subsequent saves in the same request scope
- add integration coverage that simulates audit persistence failure and verifies session creation still succeeds

## Root Cause
`POST /sessions` always evaluates trial access, and trial access always attempted to persist an audit record. If that audit `SaveChangesAsync` failed, the exception bubbled and returned HTTP 500, blocking session creation and downstream workflows.

## Test Evidence
Red (before fix):
- `CreateSession_Should_Allow_Allowlisted_User_When_TrialAuditPersistence_Fails` returned `500` instead of `201`

Green (after fix):
- `DOTNET_CLI_HOME=/tmp dotnet test backend/tests/Agon.Integration.Tests/Agon.Integration.Tests.csproj --filter "FullyQualifiedName~CreateSession_Should_Allow_Allowlisted_User_When_TrialAuditPersistence_Fails" --verbosity minimal`
  - Passed: 1, Failed: 0
- `DOTNET_CLI_HOME=/tmp dotnet test backend/tests/Agon.Integration.Tests/Agon.Integration.Tests.csproj --verbosity minimal`
  - Passed: 88, Failed: 0, Skipped: 2, Total: 90
- `DOTNET_CLI_HOME=/tmp dotnet test backend/tests/Agon.Integration.Tests/Agon.Integration.Tests.csproj --filter "FullyQualifiedName~LargeDocumentRegressionCorpusIntegrationTests" --verbosity minimal`
  - Passed: 1, Failed: 0

## Changeset
Not applicable: this PR does not modify `cli/`.