### PR TITLE
fix(api): add startup schema guard for sessions council_run columns

### DIFF
--- a/backend/src/Agon.Api/Program.cs
+++ b/backend/src/Agon.Api/Program.cs
@@ -659,6 +659,7 @@ using (var scope = app.Services.CreateScope())
     {
         startupLogger.LogInformation("Applying PostgreSQL migrations...");
         dbContext.Database.Migrate();
+        EnsureSessionsCouncilRunColumns(dbContext, startupLogger);
         startupLogger.LogInformation("PostgreSQL migrations applied.");
     }
 }
@@ -761,6 +762,24 @@ static string ReplaceEnvVars(string value)
         var envVarName = match.Groups[1].Value;
         return Environment.GetEnvironmentVariable(envVarName) ?? match.Value;
     });
+}
+
+static void EnsureSessionsCouncilRunColumns(AgonDbContext dbContext, ILogger startupLogger)
+{
+    // Defensive startup guard: schema drift has previously caused runtime 500s when
+    // the code expects council_run_* columns but the sessions table is missing them.
+    const string ensureColumnsSql = """
+        ALTER TABLE IF EXISTS sessions
+            ADD COLUMN IF NOT EXISTS council_run_phase text,
+            ADD COLUMN IF NOT EXISTS council_run_started_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS council_run_first_progress_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS council_run_last_progress_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS council_run_completed_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS council_run_failed_reason text;
+        """;
+
+    dbContext.Database.ExecuteSqlRaw(ensureColumnsSql);
+    startupLogger.LogInformation("Ensured sessions.council_run_* columns exist.");
 }
 
 static bool IsConfiguredValue(string? value)


### PR DESCRIPTION
## Summary
- add a startup schema guard after `Database.Migrate()` to ensure `sessions.council_run_*` columns exist
- this is an idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` safeguard for known schema-drift failures in `api-dev`

## Why
`api-dev` is throwing runtime 500s on `/sessions` and `/sessions/.../attachments` with:

- `Npgsql.PostgresException 42703: column s.council_run_completed_at does not exist`

When this happens, users cannot create/list sessions or attach documents, so downstream analysis/council flows fail before they even start.

## Change Details
- file changed: `backend/src/Agon.Api/Program.cs`
- after migrations, execute defensive SQL:
  - `ADD COLUMN IF NOT EXISTS council_run_phase`
  - `ADD COLUMN IF NOT EXISTS council_run_started_at`
  - `ADD COLUMN IF NOT EXISTS council_run_first_progress_at`
  - `ADD COLUMN IF NOT EXISTS council_run_last_progress_at`
  - `ADD COLUMN IF NOT EXISTS council_run_completed_at`
  - `ADD COLUMN IF NOT EXISTS council_run_failed_reason`
- logs confirmation: `Ensured sessions.council_run_* columns exist.`

## Validation
- `DOTNET_CLI_HOME=/tmp dotnet test backend/tests/Agon.Integration.Tests/Agon.Integration.Tests.csproj --filter "FullyQualifiedName~TrialAccessIntegrationTests" --verbosity minimal`
  - Passed: 18, Failed: 0

## Changeset
- Not applicable (no `cli/` changes).