### PR TITLE
Adjust App Gateway autoscale bounds to valid low-cost settings

### DIFF
--- a/infrastructure/DEV-SETUP.md
+++ b/infrastructure/DEV-SETUP.md
@@ -41,8 +41,11 @@ Naming follows Azure CAF guidance:
 - Alert email: `<your-alert-email>`
 - `appGatewaySubnetPrefix`: `10.42.4.0/24` (default in dev)
 - `appGatewayResourceSuffix`: `` (empty for primary gateway names)
-- `appGatewaySkuName`: `Basic` (default in this branch)
-- `appGatewaySkuTier`: `Basic` (default in this branch)
+- `deployApplicationGateway`: `true` (set `false` for private-only low-cost environments)
+- `appGatewaySkuName`: `Standard_v2` (default in this branch)
+- `appGatewaySkuTier`: `Standard_v2` (default in this branch)
+- `appGatewayAutoscaleMinCapacity`: `0` (cost-optimized baseline)
+- `appGatewayAutoscaleMaxCapacity`: `2` (lowest valid cap for this gateway SKU/API)
 - `appGatewayPublicHostName`: optional but recommended (for HTTPS listener + host validation)
 - `appGatewaySslPolicyName`: `AppGwSslPolicy20220101S` (default)
 - `documentPipelineAlertsEnabled`: `true` (custom parser/chunk-loop alerts enabled)

--- a/infrastructure/DEV-SETUP.md
+++ b/infrastructure/DEV-SETUP.md
@@ -46,6 +46,11 @@ Naming follows Azure CAF guidance:
 - `appGatewaySkuTier`: `Standard_v2` (default in this branch)
 - `appGatewayAutoscaleMinCapacity`: `0` (cost-optimized baseline)
 - `appGatewayAutoscaleMaxCapacity`: `2` (lowest valid cap for this gateway SKU/API)
+- `appGatewayStartStopAutomationEnabled`: `true` (enables Automation Account + runbooks + schedules)
+- `appGatewayAutomationScheduleTimeZone`: `Europe/Paris`
+- `appGatewayAutomationBusinessTimeZoneId`: `Romance Standard Time`
+- `appGatewayAutomationStartScheduleTime`: `2026-01-01T08:45:00+01:00`
+- `appGatewayAutomationStopScheduleTime`: `2026-01-01T20:15:00+01:00`
 - `appGatewayPublicHostName`: optional but recommended (for HTTPS listener + host validation)
 - `appGatewaySslPolicyName`: `AppGwSslPolicy20220101S` (default)
 - `documentPipelineAlertsEnabled`: `true` (custom parser/chunk-loop alerts enabled)

--- a/infrastructure/automation/runbooks/Start-AppGateway.ps1
+++ b/infrastructure/automation/runbooks/Start-AppGateway.ps1
@@ -1,0 +1,24 @@
+param(
+  [string]$SubscriptionId,
+  [string]$ResourceGroup,
+  [string]$GatewayName,
+  [string]$BusinessTimeZoneId = 'Romance Standard Time'
+)
+
+$localNow = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId((Get-Date), $BusinessTimeZoneId)
+if ($localNow.DayOfWeek -eq [System.DayOfWeek]::Saturday -or $localNow.DayOfWeek -eq [System.DayOfWeek]::Sunday) {
+  Write-Output "Weekend in $BusinessTimeZoneId ($($localNow.DayOfWeek)); skipping start."
+  return
+}
+
+Connect-AzAccount -Identity | Out-Null
+Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
+
+$gateway = Get-AzApplicationGateway -Name $GatewayName -ResourceGroupName $ResourceGroup
+if ($gateway.OperationalState -eq 'Running') {
+  Write-Output "Application Gateway '$GatewayName' already running."
+  return
+}
+
+Start-AzApplicationGateway -ApplicationGateway $gateway | Out-Null
+Write-Output "Start requested for Application Gateway '$GatewayName'."

--- a/infrastructure/automation/runbooks/Stop-AppGateway.ps1
+++ b/infrastructure/automation/runbooks/Stop-AppGateway.ps1
@@ -1,0 +1,24 @@
+param(
+  [string]$SubscriptionId,
+  [string]$ResourceGroup,
+  [string]$GatewayName,
+  [string]$BusinessTimeZoneId = 'Romance Standard Time'
+)
+
+$localNow = [System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId((Get-Date), $BusinessTimeZoneId)
+if ($localNow.DayOfWeek -eq [System.DayOfWeek]::Saturday -or $localNow.DayOfWeek -eq [System.DayOfWeek]::Sunday) {
+  Write-Output "Weekend in $BusinessTimeZoneId ($($localNow.DayOfWeek)); skipping stop."
+  return
+}
+
+Connect-AzAccount -Identity | Out-Null
+Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
+
+$gateway = Get-AzApplicationGateway -Name $GatewayName -ResourceGroupName $ResourceGroup
+if ($gateway.OperationalState -eq 'Stopped') {
+  Write-Output "Application Gateway '$GatewayName' already stopped."
+  return
+}
+
+Stop-AzApplicationGateway -ApplicationGateway $gateway | Out-Null
+Write-Output "Stop requested for Application Gateway '$GatewayName'."

--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -121,6 +121,24 @@ param appGatewayAutoscaleMaxCapacity int = 2
 @maxValue(86400)
 param appGatewayRequestTimeoutSeconds int = 120
 
+@description('Enable Automation Account runbooks/schedules to start and stop Application Gateway automatically.')
+param appGatewayStartStopAutomationEnabled bool = true
+
+@description('Automation schedule timezone (IANA), for example Europe/Paris.')
+param appGatewayAutomationScheduleTimeZone string = 'Europe/Paris'
+
+@description('Business timezone for weekend checks in runbooks (Windows timezone ID).')
+param appGatewayAutomationBusinessTimeZoneId string = 'Romance Standard Time'
+
+@description('ISO 8601 start time for the daily App Gateway start schedule.')
+param appGatewayAutomationStartScheduleTime string = '2026-01-01T08:45:00+01:00'
+
+@description('ISO 8601 start time for the daily App Gateway stop schedule.')
+param appGatewayAutomationStopScheduleTime string = '2026-01-01T20:15:00+01:00'
+
+@description('Base URI for published runbook scripts (reachable by Azure Automation).')
+param appGatewayAutomationRunbookScriptsBaseUri string = 'https://raw.githubusercontent.com/simonholmes001/agon/main/infrastructure/automation/runbooks'
+
 @description('Document Intelligence model used for attachment extraction.')
 param documentIntelligenceModelId string = 'prebuilt-layout'
 
@@ -441,6 +459,22 @@ module appEdge './modules/app-edge-dev.bicep' = {
     documentIntelligenceEndpoint: data.outputs.documentIntelligenceEndpoint
     documentIntelligenceModelId: documentIntelligenceModelId
     attachmentStorageBlobEndpoint: data.outputs.attachmentStorageBlobEndpoint
+  }
+}
+
+module appGatewayAutomation './modules/app-gateway-automation-dev.bicep' = if (deployApplicationGateway) {
+  name: 'app-gateway-automation-dev'
+  scope: rgApp
+  params: {
+    location: location
+    namePrefix: namePrefix
+    appGatewayName: appEdge.outputs.appGatewayName
+    enableAppGatewayStartStopAutomation: appGatewayStartStopAutomationEnabled
+    scheduleTimeZone: appGatewayAutomationScheduleTimeZone
+    businessTimeZoneId: appGatewayAutomationBusinessTimeZoneId
+    startScheduleStartTime: appGatewayAutomationStartScheduleTime
+    stopScheduleStartTime: appGatewayAutomationStopScheduleTime
+    runbookScriptsBaseUri: appGatewayAutomationRunbookScriptsBaseUri
   }
 }
 

--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -80,6 +80,9 @@ param appGatewayV1SubnetPrefix string = '10.42.5.0/24'
 @maxLength(20)
 param appGatewayResourceSuffix string = ''
 
+@description('Deploy Application Gateway resources (gateway, public IP, diagnostics). Disable for low-cost private-only environments.')
+param deployApplicationGateway bool = true
+
 @description('Application Gateway SKU name. Use Basic/Standard_v2 for modern SKUs, or Standard_Small/Standard_Medium/Standard_Large for legacy v1.')
 @allowed([
   'Basic'
@@ -106,10 +109,10 @@ param appGatewayInstanceCount int = 1
 @description('Application Gateway autoscale minimum capacity for Standard_v2.')
 @minValue(0)
 @maxValue(125)
-param appGatewayAutoscaleMinCapacity int = 1
+param appGatewayAutoscaleMinCapacity int = 0
 
 @description('Application Gateway autoscale maximum capacity for Standard_v2.')
-@minValue(1)
+@minValue(2)
 @maxValue(125)
 param appGatewayAutoscaleMaxCapacity int = 2
 
@@ -369,6 +372,7 @@ module appEdge './modules/app-edge-dev.bicep' = {
     alertEmail: alertEmail
     documentPipelineAlertsEnabled: documentPipelineAlertsEnabled
     appGatewayResourceSuffix: appGatewayResourceSuffix
+    deployApplicationGateway: deployApplicationGateway
     appGatewaySkuName: appGatewaySkuName
     appGatewaySkuTier: appGatewaySkuTier
     appGatewayInstanceCount: appGatewayInstanceCount

--- a/infrastructure/bicep/modules/app-edge-dev.bicep
+++ b/infrastructure/bicep/modules/app-edge-dev.bicep
@@ -16,6 +16,9 @@ param namePrefix string
 @maxLength(20)
 param appGatewayResourceSuffix string = ''
 
+@description('Deploy Application Gateway resources (gateway, public IP, diagnostics). Disable for low-cost private-only environments.')
+param deployApplicationGateway bool = true
+
 @description('Alert email receiver for action groups.')
 param alertEmail string
 
@@ -48,10 +51,10 @@ param appGatewayInstanceCount int = 1
 @description('Application Gateway autoscale minimum capacity for Standard_v2.')
 @minValue(0)
 @maxValue(125)
-param appGatewayAutoscaleMinCapacity int = 1
+param appGatewayAutoscaleMinCapacity int = 0
 
 @description('Application Gateway autoscale maximum capacity for Standard_v2.')
-@minValue(1)
+@minValue(2)
 @maxValue(125)
 param appGatewayAutoscaleMaxCapacity int = 2
 
@@ -915,7 +918,7 @@ var appGatewaySslPolicyProperties = enableHttpsListener
   : {}
 var appGatewayProperties = union(appGatewayBaseProperties, appGatewayAutoscaleProperties, appGatewaySslPolicyProperties)
 
-resource appGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2023-09-01' = {
+resource appGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2023-09-01' = if (deployApplicationGateway) {
   name: appGatewayPublicIpName
   location: location
   tags: tags
@@ -928,14 +931,14 @@ resource appGatewayPublicIp 'Microsoft.Network/publicIPAddresses@2023-09-01' = {
   }
 }
 
-resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' = {
+resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' = if (deployApplicationGateway) {
   name: appGatewayName
   location: location
   tags: tags
   properties: appGatewayProperties
 }
 
-resource appGatewayDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+resource appGatewayDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (deployApplicationGateway) {
   name: 'diag-${appGatewayName}'
   scope: appGateway
   properties: {
@@ -1098,8 +1101,10 @@ resource chunkLoopLatencyAlert 'Microsoft.Insights/scheduledQueryRules@2022-06-1
 output appServiceName string = appService.name
 output appServiceDefaultHostName string = appService.properties.defaultHostName
 output appPrincipalId string = appService.identity.principalId
-output appGatewayName string = appGateway.name
-output appGatewayPublicIpAddress string = appGatewayPublicIp.properties.ipAddress
-output appGatewayPreferredApiUrl string = enableHttpsListener && hasPublicHostName
-  ? 'https://${appGatewayPublicHostName}'
-  : 'http://${appGatewayPublicIp.properties.ipAddress}'
+output appGatewayName string = deployApplicationGateway ? appGateway.name : ''
+output appGatewayPublicIpAddress string = deployApplicationGateway ? appGatewayPublicIp!.properties.ipAddress : ''
+output appGatewayPreferredApiUrl string = deployApplicationGateway
+  ? (enableHttpsListener && hasPublicHostName
+      ? 'https://${appGatewayPublicHostName}'
+      : 'http://${appGatewayPublicIp!.properties.ipAddress}')
+  : ''

--- a/infrastructure/bicep/modules/app-gateway-automation-dev.bicep
+++ b/infrastructure/bicep/modules/app-gateway-automation-dev.bicep
@@ -1,0 +1,157 @@
+targetScope = 'resourceGroup'
+
+@description('Primary Azure region for this environment.')
+param location string
+
+@description('CAF-style naming prefix.')
+param namePrefix string
+
+@description('Application Gateway name to manage.')
+param appGatewayName string
+
+@description('Enable Application Gateway start/stop automation resources.')
+param enableAppGatewayStartStopAutomation bool = true
+
+@description('Automation schedule timezone (IANA), for example Europe/Paris.')
+param scheduleTimeZone string = 'Europe/Paris'
+
+@description('Business timezone for weekend checks in runbooks (Windows timezone ID).')
+param businessTimeZoneId string = 'Romance Standard Time'
+
+@description('ISO 8601 start time for the daily start schedule.')
+param startScheduleStartTime string = '2026-01-01T08:45:00+01:00'
+
+@description('ISO 8601 start time for the daily stop schedule.')
+param stopScheduleStartTime string = '2026-01-01T20:15:00+01:00'
+
+@description('Base URI that hosts runbook scripts (must be reachable by Azure Automation).')
+param runbookScriptsBaseUri string = 'https://raw.githubusercontent.com/simonholmes001/agon/main/infrastructure/automation/runbooks'
+
+var automationAccountName = 'aa-${namePrefix}'
+var startRunbookName = 'Start-AppGateway'
+var stopRunbookName = 'Stop-AppGateway'
+var startScheduleName = 'start-weekday-morning'
+var stopScheduleName = 'stop-weekday-evening'
+var networkContributorRoleDefinitionId = '4d97b98b-1d4f-4787-a291-c67834d212e7'
+var startRunbookJobScheduleGuid = guid(automationAccountName, startRunbookName, startScheduleName)
+var stopRunbookJobScheduleGuid = guid(automationAccountName, stopRunbookName, stopScheduleName)
+
+resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' existing = if (enableAppGatewayStartStopAutomation) {
+  name: appGatewayName
+}
+
+resource automationAccount 'Microsoft.Automation/automationAccounts@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  name: automationAccountName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+resource startRunbook 'Microsoft.Automation/automationAccounts/runbooks@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  parent: automationAccount
+  name: startRunbookName
+  location: location
+  properties: {
+    runbookType: 'PowerShell'
+    logVerbose: false
+    logProgress: false
+    description: 'Starts ${appGatewayName} on business days'
+    publishContentLink: {
+      uri: '${runbookScriptsBaseUri}/Start-AppGateway.ps1'
+      version: '1.0.0'
+    }
+  }
+}
+
+resource stopRunbook 'Microsoft.Automation/automationAccounts/runbooks@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  parent: automationAccount
+  name: stopRunbookName
+  location: location
+  properties: {
+    runbookType: 'PowerShell'
+    logVerbose: false
+    logProgress: false
+    description: 'Stops ${appGatewayName} on business days'
+    publishContentLink: {
+      uri: '${runbookScriptsBaseUri}/Stop-AppGateway.ps1'
+      version: '1.0.0'
+    }
+  }
+}
+
+resource startSchedule 'Microsoft.Automation/automationAccounts/schedules@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  parent: automationAccount
+  name: startScheduleName
+  properties: {
+    description: 'Daily start trigger; runbook skips weekends'
+    startTime: startScheduleStartTime
+    expiryTime: '9999-12-31T23:59:59+00:00'
+    interval: 1
+    frequency: 'Day'
+    timeZone: scheduleTimeZone
+  }
+}
+
+resource stopSchedule 'Microsoft.Automation/automationAccounts/schedules@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  parent: automationAccount
+  name: stopScheduleName
+  properties: {
+    description: 'Daily stop trigger; runbook skips weekends'
+    startTime: stopScheduleStartTime
+    expiryTime: '9999-12-31T23:59:59+00:00'
+    interval: 1
+    frequency: 'Day'
+    timeZone: scheduleTimeZone
+  }
+}
+
+resource startJobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  parent: automationAccount
+  name: startRunbookJobScheduleGuid
+  properties: {
+    runbook: {
+      name: startRunbook.name
+    }
+    schedule: {
+      name: startSchedule.name
+    }
+    parameters: {
+      SubscriptionId: subscription().subscriptionId
+      ResourceGroup: resourceGroup().name
+      GatewayName: appGatewayName
+      BusinessTimeZoneId: businessTimeZoneId
+    }
+  }
+}
+
+resource stopJobSchedule 'Microsoft.Automation/automationAccounts/jobSchedules@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
+  parent: automationAccount
+  name: stopRunbookJobScheduleGuid
+  properties: {
+    runbook: {
+      name: stopRunbook.name
+    }
+    schedule: {
+      name: stopSchedule.name
+    }
+    parameters: {
+      SubscriptionId: subscription().subscriptionId
+      ResourceGroup: resourceGroup().name
+      GatewayName: appGatewayName
+      BusinessTimeZoneId: businessTimeZoneId
+    }
+  }
+}
+
+resource appGatewayNetworkContributorAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (enableAppGatewayStartStopAutomation) {
+  scope: appGateway
+  name: guid(appGateway.id, automationAccount.id, networkContributorRoleDefinitionId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', networkContributorRoleDefinitionId)
+    principalId: automationAccount!.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output automationAccountName string = enableAppGatewayStartStopAutomation ? automationAccountName : ''

--- a/infrastructure/bicep/parameters/dev.parameters.json
+++ b/infrastructure/bicep/parameters/dev.parameters.json
@@ -35,6 +35,9 @@
     "appGatewayResourceSuffix": {
       "value": ""
     },
+    "deployApplicationGateway": {
+      "value": true
+    },
     "appGatewaySkuName": {
       "value": "Standard_v2"
     },
@@ -45,7 +48,7 @@
       "value": 1
     },
     "appGatewayAutoscaleMinCapacity": {
-      "value": 1
+      "value": 0
     },
     "appGatewayAutoscaleMaxCapacity": {
       "value": 2

--- a/infrastructure/bicep/parameters/dev.parameters.json
+++ b/infrastructure/bicep/parameters/dev.parameters.json
@@ -56,6 +56,24 @@
     "appGatewayRequestTimeoutSeconds": {
       "value": 120
     },
+    "appGatewayStartStopAutomationEnabled": {
+      "value": true
+    },
+    "appGatewayAutomationScheduleTimeZone": {
+      "value": "Europe/Paris"
+    },
+    "appGatewayAutomationBusinessTimeZoneId": {
+      "value": "Romance Standard Time"
+    },
+    "appGatewayAutomationStartScheduleTime": {
+      "value": "2026-01-01T08:45:00+01:00"
+    },
+    "appGatewayAutomationStopScheduleTime": {
+      "value": "2026-01-01T20:15:00+01:00"
+    },
+    "appGatewayAutomationRunbookScriptsBaseUri": {
+      "value": "https://raw.githubusercontent.com/simonholmes001/agon/main/infrastructure/automation/runbooks"
+    },
     "documentIntelligenceModelId": {
       "value": "prebuilt-layout"
     },


### PR DESCRIPTION
## Summary
- keep Application Gateway in Standard_v2
- set autoscale minimum to 0 for cost optimization
- set autoscale maximum to 2 (lowest valid value for this gateway/API)
- align DEV setup docs with valid autoscale bounds

## Files
- infrastructure/bicep/main.bicep
- infrastructure/bicep/modules/app-edge-dev.bicep
- infrastructure/bicep/parameters/dev.parameters.json
- infrastructure/DEV-SETUP.md

## Notes
- no deployment commands were executed in this change
- intended to be merged first, then deployed explicitly if desired