### PR TITLE
Fix App Gateway automation start/stop runbooks for Azure module compatibility

### DIFF
--- a/infrastructure/automation/runbooks/Start-AppGateway.ps1
+++ b/infrastructure/automation/runbooks/Start-AppGateway.ps1
@@ -20,5 +20,7 @@ if ($gateway.OperationalState -eq 'Running') {
   return
 }
 
-Start-AzApplicationGateway -ApplicationGateway $gateway | Out-Null
+Invoke-AzRestMethod `
+  -Method POST `
+  -Path "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Network/applicationGateways/$GatewayName/start?api-version=2023-09-01" | Out-Null
 Write-Output "Start requested for Application Gateway '$GatewayName'."

--- a/infrastructure/automation/runbooks/Stop-AppGateway.ps1
+++ b/infrastructure/automation/runbooks/Stop-AppGateway.ps1
@@ -20,5 +20,7 @@ if ($gateway.OperationalState -eq 'Stopped') {
   return
 }
 
-Stop-AzApplicationGateway -ApplicationGateway $gateway | Out-Null
+Invoke-AzRestMethod `
+  -Method POST `
+  -Path "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Network/applicationGateways/$GatewayName/stop?api-version=2023-09-01" | Out-Null
 Write-Output "Stop requested for Application Gateway '$GatewayName'."


### PR DESCRIPTION
## Summary
- Replace `Start-AzApplicationGateway` / `Stop-AzApplicationGateway` cmdlet calls in Automation runbooks with ARM REST calls via `Invoke-AzRestMethod`.
- Keep existing business-day/weekend guard and state checks unchanged.

## Why
Azure Automation in this environment runs an older `Az.Network` module surface that caused parameter binding errors in scheduled jobs (e.g. `InputObject` / `Name` mismatch), leading to unreliable start/stop behavior.

## Changes
- `infrastructure/automation/runbooks/Start-AppGateway.ps1`
  - Use `POST .../applicationGateways/{name}/start?api-version=2023-09-01`
- `infrastructure/automation/runbooks/Stop-AppGateway.ps1`
  - Use `POST .../applicationGateways/{name}/stop?api-version=2023-09-01`

## Validation performed
- Published updated runbooks in Azure Automation (`aa-agon-dev-swc`).
- Executed stop runbook successfully and observed gateway transition to `Stopped`.
- Executed start runbook successfully and observed gateway transition back to `Running`.
- Confirmed no parameter-binding errors in latest successful stop/start runs.

## Operational note
This makes runbooks resilient to Automation module version drift by avoiding module-specific cmdlet parameter-set differences.