### PR TITLE
Fix Automation Account deployment by setting SKU in Bicep module

### DIFF
--- a/infrastructure/bicep/modules/app-gateway-automation-dev.bicep
+++ b/infrastructure/bicep/modules/app-gateway-automation-dev.bicep
@@ -43,6 +43,9 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' existing 
 resource automationAccount 'Microsoft.Automation/automationAccounts@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
   name: automationAccountName
   location: location
+  sku: {
+    name: 'Basic'
+  }
   identity: {
     type: 'SystemAssigned'
   }


### PR DESCRIPTION
## Summary
Add required `sku` to the Automation Account resource in `app-gateway-automation-dev.bicep`.

## Problem
Infrastructure deployment failed in `app-gateway-automation-dev` with Automation Account `BadRequest` indicating the request body was missing required fields.

## Change
- `infrastructure/bicep/modules/app-gateway-automation-dev.bicep`
  - Add:
    - `sku: { name: 'Basic' }`

## Why this fixes it
Automation Account create/update payloads require required account fields; including `sku` makes the resource body valid and stabilizes deployment updates.

## Validation
- Branch contains only one commit ahead of `main` for this fix (`55da3ca`).
- Ready for pipeline rerun after merge.