### PR TITLE
Fix Automation Account payload: set properties.sku for 2023-11-01 API

### DIFF
--- a/infrastructure/bicep/modules/app-gateway-automation-dev.bicep
+++ b/infrastructure/bicep/modules/app-gateway-automation-dev.bicep
@@ -43,11 +43,13 @@ resource appGateway 'Microsoft.Network/applicationGateways@2023-09-01' existing 
 resource automationAccount 'Microsoft.Automation/automationAccounts@2023-11-01' = if (enableAppGatewayStartStopAutomation) {
   name: automationAccountName
   location: location
-  sku: {
-    name: 'Basic'
-  }
   identity: {
     type: 'SystemAssigned'
+  }
+  properties: {
+    sku: {
+      name: 'Basic'
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Fix Automation Account deployment payload shape for `Microsoft.Automation/automationAccounts@2023-11-01`.

## Problem
Infrastructure deployment still fails in `app-gateway-automation-dev` with:
- `BadRequest`
- `The request body on Account must be present...`

The previous attempt used top-level `sku`, which is not valid for this type/API shape.

## Change
- `infrastructure/bicep/modules/app-gateway-automation-dev.bicep`
  - Remove top-level `sku`
  - Set `properties.sku.name = 'Basic'`

## Why
Live resource shape in Azure shows SKU under `properties.sku`, not root `sku`.

## Commit
- `7b44793`