### PR TITLE
Migrate dev edge from Application Gateway to APIM

### DIFF
--- a/.github/workflows/backend-deploy-dev.yaml
+++ b/.github/workflows/backend-deploy-dev.yaml
@@ -312,7 +312,7 @@ jobs:
               --resource-group "${{ steps.app.outputs.app_resource_group }}" \
               --name "${{ steps.app.outputs.app_name }}"
 
-      - name: Verify health through Application Gateway
+      - name: Verify health through APIM edge
         if: steps.guard.outputs.deploy == 'true'
         uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2.2.0
         env:
@@ -321,58 +321,41 @@ jobs:
           inlineScript: |
             set -euo pipefail
             APP_RG="${{ steps.app.outputs.app_resource_group }}"
-            HEALTH_URL=""
-            if [ -n "${AGON_API_HOSTNAME:-}" ]; then
-              HEALTH_URL="https://${AGON_API_HOSTNAME}/health"
-              echo "Checking health over HTTPS host endpoint: ${HEALTH_URL}"
-            else
-              echo "::warning::AGON_API_HOSTNAME secret not set. Falling back to legacy HTTP IP health check."
-              AGW_NAME=$(az network application-gateway list \
+            APIM_NAME=$(az apim list \
+              --resource-group "${APP_RG}" \
+              --query "[?tags.environment=='dev' && tags.workload=='agon'].name | [0]" \
+              --output tsv)
+
+            if [ -z "${APIM_NAME}" ] || [ "${APIM_NAME}" = "null" ]; then
+              APIM_NAME=$(az apim list \
                 --resource-group "${APP_RG}" \
-                --query "[?tags.environment=='dev' && tags.workload=='agon'].name | [0]" \
+                --query "[?starts_with(name, 'apim-agon-dev-')].name | [0]" \
                 --output tsv)
-
-              if [ -z "${AGW_NAME}" ] || [ "${AGW_NAME}" = "null" ]; then
-                AGW_NAME=$(az network application-gateway list \
-                  --resource-group "${APP_RG}" \
-                  --query "[?starts_with(name, 'agw-agon-dev-')].name | [0]" \
-                  --output tsv)
-              fi
-
-              if [ -z "${AGW_NAME}" ] || [ "${AGW_NAME}" = "null" ]; then
-                echo "Failed to resolve Application Gateway in ${APP_RG}."
-                exit 1
-              fi
-
-              AGW_PIP_ID=$(az network application-gateway show \
-                --resource-group "${APP_RG}" \
-                --name "${AGW_NAME}" \
-                --query "frontendIPConfigurations[0].publicIPAddress.id" \
-                --output tsv)
-
-              if [ -z "${AGW_PIP_ID}" ] || [ "${AGW_PIP_ID}" = "null" ]; then
-                echo "Failed to resolve Application Gateway public IP reference."
-                exit 1
-              fi
-
-              AGW_IP=$(az network public-ip show \
-                --ids "${AGW_PIP_ID}" \
-                --query ipAddress \
-                --output tsv)
-
-              if [ -z "${AGW_IP}" ] || [ "${AGW_IP}" = "null" ]; then
-                echo "Failed to resolve Application Gateway public IP."
-                exit 1
-              fi
-
-              HEALTH_URL="http://${AGW_IP}/health"
-              echo "Checking health at ${HEALTH_URL}"
             fi
+
+            if [ -z "${APIM_NAME}" ] || [ "${APIM_NAME}" = "null" ]; then
+              echo "::error::Unable to resolve APIM service in ${APP_RG}."
+              exit 1
+            fi
+
+            APIM_GATEWAY_URL=$(az apim show \
+              --resource-group "${APP_RG}" \
+              --name "${APIM_NAME}" \
+              --query "gatewayUrl" \
+              --output tsv)
+
+            if [ -z "${APIM_GATEWAY_URL}" ] || [ "${APIM_GATEWAY_URL}" = "null" ]; then
+              echo "::error::APIM gatewayUrl is unavailable for ${APIM_NAME}."
+              exit 1
+            fi
+
+            HEALTH_URL="${APIM_GATEWAY_URL%/}/api/health"
+            echo "Checking APIM health endpoint: ${HEALTH_URL}"
 
             for i in {1..30}; do
               STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${HEALTH_URL}" || true)
               if [ "${STATUS}" = "200" ]; then
-                echo "Backend is healthy via Application Gateway."
+                echo "Backend is healthy via configured edge endpoint."
                 break
               fi
               echo "Attempt ${i}/30: status=${STATUS}, waiting..."
@@ -380,37 +363,6 @@ jobs:
             done
 
             if [ "${STATUS}" != "200" ]; then
-              echo "Backend failed health check through Application Gateway."
+              echo "Backend failed health check through configured edge endpoint."
               exit 1
-            fi
-
-            if [ -n "${AGON_API_HOSTNAME:-}" ]; then
-              HTTP_HEALTH_URL="http://${AGON_API_HOSTNAME}/health"
-              EXPECTED_REDIRECT_PREFIX="https://${AGON_API_HOSTNAME}/"
-              echo "Validating HTTP to HTTPS redirect behavior at ${HTTP_HEALTH_URL}"
-
-              REDIRECT_OK="false"
-              for i in {1..15}; do
-                RESPONSE=$(curl -s -o /dev/null -w "%{http_code} %{redirect_url}" "${HTTP_HEALTH_URL}" || true)
-                REDIRECT_STATUS="${RESPONSE%% *}"
-                if [ "${RESPONSE}" = "${REDIRECT_STATUS}" ]; then
-                  REDIRECT_URL=""
-                else
-                  REDIRECT_URL="${RESPONSE#* }"
-                fi
-
-                if [[ "${REDIRECT_STATUS}" =~ ^30[1278]$ ]] && [[ "${REDIRECT_URL}" == ${EXPECTED_REDIRECT_PREFIX}* ]]; then
-                  REDIRECT_OK="true"
-                  echo "HTTP redirect verified: ${REDIRECT_STATUS} -> ${REDIRECT_URL}"
-                  break
-                fi
-
-                echo "Redirect attempt ${i}/15: status=${REDIRECT_STATUS}, location=${REDIRECT_URL}"
-                sleep 10
-              done
-
-              if [ "${REDIRECT_OK}" != "true" ]; then
-                echo "HTTP to HTTPS redirect validation failed for ${HTTP_HEALTH_URL}."
-                exit 1
-              fi
             fi

--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -76,12 +76,63 @@ param appGatewaySubnetPrefix string = '10.42.4.0/24'
 @description('Application Gateway dedicated subnet prefix for Basic/legacy (v1 family) SKUs.')
 param appGatewayV1SubnetPrefix string = '10.42.5.0/24'
 
+@description('API Management dedicated subnet prefix.')
+param apiManagementSubnetPrefix string = '10.42.6.0/24'
+
 @description('Optional suffix for Application Gateway resources to support parallel replacement cutovers (for example: v1).')
 @maxLength(20)
 param appGatewayResourceSuffix string = ''
 
 @description('Deploy Application Gateway resources (gateway, public IP, diagnostics). Disable for low-cost private-only environments.')
-param deployApplicationGateway bool = true
+param deployApplicationGateway bool = false
+
+@description('Deploy Azure API Management as the primary API ingress.')
+param deployApiManagement bool = true
+
+@description('API Management service SKU.')
+@allowed([
+  'Consumption'
+  'Developer'
+  'Basic'
+  'Standard'
+  'Premium'
+  'BasicV2'
+  'StandardV2'
+])
+param apiManagementSkuName string = 'Developer'
+
+@description('API Management capacity units (ignored by Consumption SKU).')
+@minValue(0)
+param apiManagementSkuCapacity int = 1
+
+@description('Publisher display name for API Management.')
+param apiManagementPublisherName string = 'Agon Platform'
+
+@description('Public hostname for APIM-backed API endpoint (for example: api-dev.example.com).')
+param apiManagementGatewayHostName string = ''
+
+@description('API Management virtual network mode.')
+@allowed([
+  'External'
+  'Internal'
+  'None'
+])
+param apiManagementVirtualNetworkType string = 'External'
+
+@description('APIM per-minute rate limit by caller IP.')
+@minValue(1)
+param apiManagementRateLimitCallsPerMinute int = 120
+
+@description('APIM per-hour quota by caller IP.')
+@minValue(1)
+param apiManagementQuotaCallsPerHour int = 2000
+
+@description('Maximum request payload size (bytes) validated by APIM policy.')
+@minValue(1024)
+param apiManagementMaxRequestSizeBytes int = 4194304
+
+@description('Optional APIM inbound CIDR allowlist. Empty means open ingress to APIM gateway.')
+param apiManagementAllowedCidrs array = []
 
 @description('Application Gateway SKU name. Use Basic/Standard_v2 for modern SKUs, or Standard_Small/Standard_Medium/Standard_Large for legacy v1.')
 @allowed([
@@ -237,7 +288,7 @@ param attachmentProcessingChunkLoopMaxChunkNoteChars int = 1200
 param attachmentProcessingChunkLoopMaxFinalNotesPerAgent int = 8
 
 @description('Enable JWT bearer authentication in the backend API.')
-param authEnabled bool = false
+param authEnabled bool = true
 
 @description('JWT authority URL for Microsoft Entra validation.')
 param jwtAuthority string = ''
@@ -352,6 +403,7 @@ module network './modules/network-dev.bicep' = {
     postgresSubnetPrefix: postgresSubnetPrefix
     appGatewaySubnetPrefix: appGatewaySubnetPrefix
     appGatewayV1SubnetPrefix: appGatewayV1SubnetPrefix
+    apiManagementSubnetPrefix: apiManagementSubnetPrefix
   }
 }
 
@@ -394,6 +446,17 @@ module appEdge './modules/app-edge-dev.bicep' = {
     documentPipelineAlertsEnabled: documentPipelineAlertsEnabled
     appGatewayResourceSuffix: appGatewayResourceSuffix
     deployApplicationGateway: deployApplicationGateway
+    deployApiManagement: deployApiManagement
+    apiManagementSkuName: apiManagementSkuName
+    apiManagementSkuCapacity: apiManagementSkuCapacity
+    apiManagementPublisherName: apiManagementPublisherName
+    apiManagementPublisherEmail: alertEmail
+    apiManagementGatewayHostName: apiManagementGatewayHostName
+    apiManagementVirtualNetworkType: apiManagementVirtualNetworkType
+    apiManagementRateLimitCallsPerMinute: apiManagementRateLimitCallsPerMinute
+    apiManagementQuotaCallsPerHour: apiManagementQuotaCallsPerHour
+    apiManagementMaxRequestSizeBytes: apiManagementMaxRequestSizeBytes
+    apiManagementAllowedCidrs: apiManagementAllowedCidrs
     appGatewaySkuName: appGatewaySkuName
     appGatewaySkuTier: appGatewaySkuTier
     appGatewayInstanceCount: appGatewayInstanceCount
@@ -426,6 +489,7 @@ module appEdge './modules/app-edge-dev.bicep' = {
       : (isModernAppGatewayTier ? network.outputs.appGatewaySubnetId : network.outputs.appGatewayV1SubnetId)
     privateEndpointSubnetId: network.outputs.privateEndpointSubnetId
     appServicePrivateDnsZoneId: network.outputs.appServicePrivateDnsZoneId
+    apiManagementSubnetId: network.outputs.apiManagementSubnetId
     postgresServerName: data.outputs.postgresqlServerName
     redisHostName: data.outputs.redisHostName
     openAiSecretUri: data.outputs.openAiSecretUri
@@ -539,6 +603,8 @@ output appServiceName string = appEdge.outputs.appServiceName
 output appServiceDefaultHostName string = appEdge.outputs.appServiceDefaultHostName
 output appGatewayPublicIpAddress string = appEdge.outputs.appGatewayPublicIpAddress
 output appGatewayPreferredApiUrl string = appEdge.outputs.appGatewayPreferredApiUrl
+output apiManagementName string = appEdge.outputs.apiManagementName
+output apiManagementGatewayUrl string = appEdge.outputs.apiManagementGatewayUrl
 output keyVaultName string = data.outputs.keyVaultName
 output postgresqlServerName string = data.outputs.postgresqlServerName
 output redisCacheName string = data.outputs.redisCacheName

--- a/infrastructure/bicep/modules/app-edge-dev.bicep
+++ b/infrastructure/bicep/modules/app-edge-dev.bicep
@@ -19,6 +19,42 @@ param appGatewayResourceSuffix string = ''
 @description('Deploy Application Gateway resources (gateway, public IP, diagnostics). Disable for low-cost private-only environments.')
 param deployApplicationGateway bool = true
 
+@description('Deploy Azure API Management as the primary API ingress.')
+param deployApiManagement bool = true
+
+@description('API Management service SKU.')
+@allowed([
+  'Consumption'
+  'Developer'
+  'Basic'
+  'Standard'
+  'Premium'
+  'BasicV2'
+  'StandardV2'
+])
+param apiManagementSkuName string = 'Developer'
+
+@description('API Management capacity units (ignored by Consumption SKU).')
+@minValue(0)
+param apiManagementSkuCapacity int = 1
+
+@description('Publisher display name for API Management.')
+param apiManagementPublisherName string = 'Agon Platform'
+
+@description('Publisher contact email for API Management.')
+param apiManagementPublisherEmail string
+
+@description('Public hostname for APIM-backed API endpoint (for example: api-dev.example.com).')
+param apiManagementGatewayHostName string = ''
+
+@description('API Management virtual network mode.')
+@allowed([
+  'External'
+  'Internal'
+  'None'
+])
+param apiManagementVirtualNetworkType string = 'External'
+
 @description('Alert email receiver for action groups.')
 param alertEmail string
 
@@ -64,7 +100,22 @@ param appGatewayAutoscaleMaxCapacity int = 2
 param appGatewayRequestTimeoutSeconds int = 120
 
 @description('Enable JWT bearer authentication in backend API runtime settings.')
-param authEnabled bool = false
+param authEnabled bool = true
+
+@description('APIM per-minute rate limit by caller IP.')
+@minValue(1)
+param apiManagementRateLimitCallsPerMinute int = 120
+
+@description('APIM per-hour quota by caller IP.')
+@minValue(1)
+param apiManagementQuotaCallsPerHour int = 2000
+
+@description('Maximum request payload size (bytes) validated by APIM policy.')
+@minValue(1024)
+param apiManagementMaxRequestSizeBytes int = 4194304
+
+@description('Optional APIM inbound CIDR allowlist. Empty means open ingress to APIM gateway.')
+param apiManagementAllowedCidrs array = []
 
 @description('JWT authority URL for token validation.')
 param jwtAuthority string = ''
@@ -144,6 +195,9 @@ param privateEndpointSubnetId string
 
 @description('Private DNS zone resource ID for App Service private endpoint resolution.')
 param appServicePrivateDnsZoneId string
+
+@description('API Management dedicated subnet resource ID.')
+param apiManagementSubnetId string
 
 @description('PostgreSQL server name (without DNS suffix).')
 param postgresServerName string
@@ -283,6 +337,8 @@ var uniqueSuffix = take(uniqueString(subscription().id, resourceGroup().id, name
 
 var appServicePlanName = 'asp-${namePrefix}'
 var appServiceName = 'app-${namePrefix}-${uniqueSuffix}'
+var apiManagementName = take('apim-${namePrefix}-${uniqueSuffix}', 50)
+var apiManagementApiName = 'agon-api'
 var appInsightsName = 'appi-${namePrefix}'
 var logAnalyticsName = 'log-${namePrefix}'
 var actionGroupName = 'ag-${namePrefix}-ops'
@@ -327,6 +383,35 @@ var appGatewaySku = isLegacyV1Sku
     }
 var appGatewayPublicIpSkuName = isModernAppGatewaySku ? 'Standard' : 'Basic'
 var appGatewayPublicIpAllocationMethod = isModernAppGatewaySku ? 'Static' : 'Dynamic'
+var apiManagementSku = apiManagementSkuName == 'Consumption'
+  ? {
+      name: apiManagementSkuName
+    }
+  : {
+      name: apiManagementSkuName
+      capacity: apiManagementSkuCapacity
+    }
+var hasApiManagementGatewayHostName = !empty(apiManagementGatewayHostName)
+var appServicePublicNetworkAccess = 'Disabled'
+var validatedApiManagementAllowedCidrs = deployApiManagement
+  ? (!empty(apiManagementAllowedCidrs)
+      ? apiManagementAllowedCidrs
+      : fail('apiManagementAllowedCidrs must contain at least one CIDR when deployApiManagement=true.'))
+  : []
+var apimAllowedCidrsEntries = [for cidr in validatedApiManagementAllowedCidrs: '<address>${string(cidr)}</address>']
+var apimAllowedCidrsPolicyXml = '<ip-filter action="allow">${join(apimAllowedCidrsEntries, '')}</ip-filter>'
+var apimValidateJwtPolicyXml = authEnabled && !empty(jwtAuthority) && !empty(jwtAudience)
+  ? '<validate-jwt header-name="Authorization" require-scheme="Bearer" require-expiration-time="true" require-signed-tokens="true"><openid-config url="${jwtAuthority}/.well-known/openid-configuration" /><audiences><audience>${jwtAudience}</audience></audiences></validate-jwt>'
+  : ''
+var apiManagementApiPolicyXml = '<policies><inbound><base />${apimAllowedCidrsPolicyXml}${apimValidateJwtPolicyXml}<choose><when condition="@(context.Request.Headers.ContainsKey(&quot;Content-Length&quot;) && long.Parse(context.Request.Headers.GetValueOrDefault(&quot;Content-Length&quot;,&quot;0&quot;)) &gt; ${string(apiManagementMaxRequestSizeBytes)})"><return-response><set-status code="413" reason="Payload Too Large" /></return-response></when></choose><rate-limit-by-key calls="${string(apiManagementRateLimitCallsPerMinute)}" renewal-period="60" counter-key="@(context.Request.IpAddress)" /><quota-by-key calls="${string(apiManagementQuotaCallsPerHour)}" renewal-period="3600" counter-key="@(context.Request.IpAddress)" /><choose><when condition="@(context.Request.Method != &quot;GET&quot; &amp;&amp; context.Request.Method != &quot;POST&quot; &amp;&amp; context.Request.Method != &quot;PUT&quot; &amp;&amp; context.Request.Method != &quot;PATCH&quot; &amp;&amp; context.Request.Method != &quot;DELETE&quot; &amp;&amp; context.Request.Method != &quot;OPTIONS&quot;)"><return-response><set-status code="405" reason="Method Not Allowed" /></return-response></when></choose></inbound><backend><base /></backend><outbound><base /></outbound><on-error><base /></on-error></policies>'
+var apimCatchAllMethods = [
+  'GET'
+  'POST'
+  'PUT'
+  'PATCH'
+  'DELETE'
+  'OPTIONS'
+]
 var frontendPorts = enableHttpsListener
   ? [
       {
@@ -526,7 +611,7 @@ resource appService 'Microsoft.Web/sites@2023-12-01' = {
   properties: {
     serverFarmId: appServicePlan.id
     httpsOnly: true
-    publicNetworkAccess: 'Disabled'
+    publicNetworkAccess: appServicePublicNetworkAccess
     virtualNetworkSubnetId: appSubnetId
     siteConfig: {
       ftpsState: 'Disabled'
@@ -787,6 +872,86 @@ resource appService 'Microsoft.Web/sites@2023-12-01' = {
         }
       ]
     }
+  }
+}
+
+resource apiManagement 'Microsoft.ApiManagement/service@2023-09-01-preview' = if (deployApiManagement) {
+  name: apiManagementName
+  location: location
+  tags: tags
+  sku: apiManagementSku
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    publisherEmail: apiManagementPublisherEmail
+    publisherName: apiManagementPublisherName
+    publicNetworkAccess: 'Enabled'
+    virtualNetworkType: apiManagementVirtualNetworkType
+    virtualNetworkConfiguration: apiManagementVirtualNetworkType == 'None'
+      ? null
+      : {
+          subnetResourceId: apiManagementSubnetId
+        }
+  }
+}
+
+resource apiManagementApi 'Microsoft.ApiManagement/service/apis@2023-09-01-preview' = if (deployApiManagement) {
+  name: apiManagementApiName
+  parent: apiManagement
+  properties: {
+    displayName: 'Agon API'
+    path: 'api'
+    protocols: [
+      'https'
+    ]
+    serviceUrl: 'https://${appService.properties.defaultHostName}'
+    subscriptionRequired: false
+  }
+}
+
+resource apiManagementApiCatchAllOperations 'Microsoft.ApiManagement/service/apis/operations@2023-09-01-preview' = [for method in apimCatchAllMethods: if (deployApiManagement) {
+  name: toLower(method)
+  parent: apiManagementApi
+  properties: {
+    displayName: '${method} Catch-all'
+    method: method
+    urlTemplate: '/*'
+    responses: [
+      {
+        statusCode: 200
+        description: 'Proxied'
+      }
+    ]
+  }
+}]
+
+resource apiManagementApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-09-01-preview' = if (deployApiManagement) {
+  name: 'policy'
+  parent: apiManagementApi
+  properties: {
+    format: 'rawxml'
+    value: apiManagementApiPolicyXml
+  }
+}
+
+resource apiManagementDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (deployApiManagement) {
+  name: 'diag-${apiManagementName}'
+  scope: apiManagement
+  properties: {
+    workspaceId: logAnalytics.id
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
   }
 }
 
@@ -1101,10 +1266,20 @@ resource chunkLoopLatencyAlert 'Microsoft.Insights/scheduledQueryRules@2022-06-1
 output appServiceName string = appService.name
 output appServiceDefaultHostName string = appService.properties.defaultHostName
 output appPrincipalId string = appService.identity.principalId
+output apiManagementName string = deployApiManagement ? apiManagement.name : ''
+output apiManagementGatewayUrl string = deployApiManagement
+  ? (hasApiManagementGatewayHostName
+      ? 'https://${apiManagementGatewayHostName}'
+      : 'https://${apiManagement!.properties.gatewayUrl}')
+  : ''
 output appGatewayName string = deployApplicationGateway ? appGateway.name : ''
 output appGatewayPublicIpAddress string = deployApplicationGateway ? appGatewayPublicIp!.properties.ipAddress : ''
-output appGatewayPreferredApiUrl string = deployApplicationGateway
+output appGatewayPreferredApiUrl string = deployApiManagement
+  ? (hasApiManagementGatewayHostName
+      ? 'https://${apiManagementGatewayHostName}'
+      : 'https://${apiManagement!.properties.gatewayUrl}')
+  : (deployApplicationGateway
   ? (enableHttpsListener && hasPublicHostName
       ? 'https://${appGatewayPublicHostName}'
       : 'http://${appGatewayPublicIp!.properties.ipAddress}')
-  : ''
+  : '')

--- a/infrastructure/bicep/modules/network-dev.bicep
+++ b/infrastructure/bicep/modules/network-dev.bicep
@@ -30,6 +30,9 @@ param appGatewaySubnetPrefix string
 @description('Application Gateway dedicated subnet prefix for Basic/legacy (v1 family) SKUs.')
 param appGatewayV1SubnetPrefix string
 
+@description('API Management dedicated subnet prefix.')
+param apiManagementSubnetPrefix string
+
 var tags = {
   environment: environment
   workload: workloadName
@@ -42,6 +45,7 @@ var privateEndpointSubnetName = 'snet-${namePrefix}-pep'
 var postgresSubnetName = 'snet-${namePrefix}-psql'
 var appGatewaySubnetName = 'snet-${namePrefix}-agw'
 var appGatewayV1SubnetName = 'snet-${namePrefix}-agw-v1'
+var apiManagementSubnetName = 'snet-${namePrefix}-apim'
 
 var keyVaultPrivateDnsZoneName = 'privatelink.vaultcore.azure.net'
 var redisPrivateDnsZoneName = 'privatelink.redis.cache.windows.net'
@@ -108,6 +112,12 @@ resource vnet 'Microsoft.Network/virtualNetworks@2023-11-01' = {
           addressPrefix: appGatewayV1SubnetPrefix
         }
       }
+      {
+        name: apiManagementSubnetName
+        properties: {
+          addressPrefix: apiManagementSubnetPrefix
+        }
+      }
     ]
   }
 }
@@ -135,6 +145,11 @@ resource appGatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01'
 resource appGatewayV1Subnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
   parent: vnet
   name: appGatewayV1SubnetName
+}
+
+resource apiManagementSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' existing = {
+  parent: vnet
+  name: apiManagementSubnetName
 }
 
 resource keyVaultPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
@@ -251,6 +266,7 @@ output privateEndpointSubnetId string = privateEndpointSubnet.id
 output postgresSubnetId string = postgresSubnet.id
 output appGatewaySubnetId string = appGatewaySubnet.id
 output appGatewayV1SubnetId string = appGatewayV1Subnet.id
+output apiManagementSubnetId string = apiManagementSubnet.id
 output keyVaultPrivateDnsZoneId string = keyVaultPrivateDnsZone.id
 output redisPrivateDnsZoneId string = redisPrivateDnsZone.id
 output postgresPrivateDnsZoneId string = postgresPrivateDnsZone.id

--- a/infrastructure/bicep/parameters/dev.parameters.json
+++ b/infrastructure/bicep/parameters/dev.parameters.json
@@ -32,11 +32,46 @@
     "appGatewayV1SubnetPrefix": {
       "value": "10.42.5.0/24"
     },
+    "apiManagementSubnetPrefix": {
+      "value": "10.42.6.0/24"
+    },
     "appGatewayResourceSuffix": {
       "value": ""
     },
     "deployApplicationGateway": {
+      "value": false
+    },
+    "deployApiManagement": {
       "value": true
+    },
+    "apiManagementSkuName": {
+      "value": "Developer"
+    },
+    "apiManagementSkuCapacity": {
+      "value": 1
+    },
+    "apiManagementPublisherName": {
+      "value": "Agon Platform"
+    },
+    "apiManagementGatewayHostName": {
+      "value": "api-dev.agon-agents.org"
+    },
+    "apiManagementVirtualNetworkType": {
+      "value": "External"
+    },
+    "apiManagementRateLimitCallsPerMinute": {
+      "value": 120
+    },
+    "apiManagementQuotaCallsPerHour": {
+      "value": 2000
+    },
+    "apiManagementMaxRequestSizeBytes": {
+      "value": 4194304
+    },
+    "apiManagementAllowedCidrs": {
+      "value": [
+        "0.0.0.0/0"
+      ]
     },
     "appGatewaySkuName": {
       "value": "Standard_v2"

--- a/infrastructure/docs/adr-application-gateway-to-apim-edge-migration.md
+++ b/infrastructure/docs/adr-application-gateway-to-apim-edge-migration.md
@@ -1,0 +1,88 @@
+# ADR: Replace Application Gateway API Ingress with Azure API Management
+
+## Status
+Proposed
+
+## Context
+Agon currently deploys Azure Application Gateway as the primary public API ingress. Cost optimization efforts on gateway scheduling and SKU tuning have not reduced spend sufficiently.
+
+The platform needs a lower-cost ingress model with stronger API policy controls while preserving:
+- API reliability and observability
+- clear rollback path
+- compatibility with existing backend API behavior
+
+This decision applies to API ingress for Agon backend endpoints and does not redefine broader platform perimeter controls.
+
+## Decision
+Adopt Azure API Management (APIM) as the primary API ingress for Agon in dev, with Application Gateway retained as a controlled fallback path.
+
+In this phase:
+- `deployApiManagement=true` and `deployApplicationGateway=false` by default.
+- APIM publishes `Agon API` under `/api` and forwards to the existing App Service backend.
+- App Gateway code paths remain in IaC for reversible rollback.
+
+## Alternatives Considered
+1. Keep Application Gateway only
+- Lowest migration risk
+- Does not address cost goal sufficiently
+
+2. APIM-only replacement (selected for this phase)
+- Strong API policy and productization surface
+- Potentially lower edge costs in low-to-moderate traffic profiles
+- Requires careful security posture review due to backend exposure changes
+
+3. Front Door + APIM
+- Strong edge/WAF posture for internet APIs
+- Rejected for this phase due to added cost and complexity
+
+4. App Gateway + APIM hybrid long-term
+- Minimizes cutover risk
+- Reduces expected cost benefits
+
+## Consequences
+### Positive
+- API ingress policy centralization in APIM
+- Explicit API boundary that aligns with adapter-style edge concerns
+- Cleaner API lifecycle controls (versioning, policy, products)
+
+### Negative / Tradeoffs
+- APIM does not provide WAF parity by itself
+- Current migration enables backend public network access when APIM is enabled; this is a temporary exposure tradeoff
+- Additional APIM policy/test ownership required
+
+### Risks and Mitigations
+- Risk: edge security regression
+  - Mitigation: enforce strict APIM policies, backend auth, request throttling, and continuous monitoring
+- Risk: routing/auth regressions during cutover
+  - Mitigation: parallel fallback path via retained App Gateway IaC and output-based endpoint switch
+- Risk: APIM SKU cost mismatch vs traffic profile
+  - Mitigation: validate with real traffic and monthly cost telemetry before production decision
+
+## Implementation Plan
+1. Foundation
+- Introduce APIM deployment controls and outputs in IaC
+- Keep App Gateway deployment path available for rollback
+
+2. Migration
+- Route API traffic to APIM endpoint in non-production
+- Validate health (`/health`), auth, and end-to-end API flows
+
+3. Hardening
+- Add APIM policy set (rate limiting, JWT validation where appropriate, request/response controls)
+- Tighten APIM policy baseline and backend access controls
+
+4. Production rollout
+- Controlled cutover with explicit rollback switch (`deployApplicationGateway=true` fallback)
+
+## Validation
+Success criteria:
+- APIM endpoint serves API traffic successfully in dev
+- Existing backend health and auth flows remain functional
+- Monitoring/logging visibility preserved in Log Analytics/App Insights
+- Cost profile meets target over at least one billing cycle
+
+## Review Trigger
+Reassess this decision when one of the following occurs:
+- production rollout planning begins
+- APIM monthly cost exceeds Application Gateway baseline for sustained periods
+- security review requires WAF-grade control at edge


### PR DESCRIPTION
## Summary
- replace dev edge default from Application Gateway to APIM Developer tier
- add APIM API/policies/diagnostics and VNet integration wiring
- make backend deploy health check target APIM gateway health endpoint
- keep App Gateway code path available for rollback via deployment flags
- add ADR documenting migration decision and rollback posture

## Notes
- APIM is configured for low-cost dev posture in swedencentral.
- App Gateway resources remain in code and can be re-enabled by parameters.